### PR TITLE
Standardize most of chain/ to use near_async::time.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2359,6 +2359,7 @@ dependencies = [
  "borsh 1.0.0",
  "clap",
  "indicatif",
+ "near-async",
  "near-chain",
  "near-chain-configs",
  "near-crypto",
@@ -3507,6 +3508,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "smart-default",
+ "time",
  "tracing",
 ]
 
@@ -3514,10 +3516,10 @@ dependencies = [
 name = "near-chain-primitives"
 version = "0.0.0"
 dependencies = [
- "chrono",
  "near-crypto",
  "near-primitives",
  "thiserror",
+ "time",
  "tracing",
 ]
 
@@ -3635,6 +3637,7 @@ dependencies = [
  "serde_json",
  "strum",
  "thiserror",
+ "time",
  "tracing",
  "yansi",
 ]
@@ -3972,6 +3975,7 @@ dependencies = [
  "ed25519-dalek",
  "hex",
  "hkdf",
+ "near-async",
  "near-chain",
  "near-chain-configs",
  "near-chain-primitives",
@@ -4345,6 +4349,7 @@ dependencies = [
  "itertools",
  "itoa",
  "lru",
+ "near-async",
  "near-chain",
  "near-chain-configs",
  "near-chunks",
@@ -4385,6 +4390,7 @@ dependencies = [
  "openssl",
  "serde",
  "serde_json",
+ "time",
  "tracing",
 ]
 

--- a/chain/chain-primitives/Cargo.toml
+++ b/chain/chain-primitives/Cargo.toml
@@ -12,8 +12,8 @@ publish = true
 workspace = true
 
 [dependencies]
-chrono.workspace = true
 thiserror.workspace = true
+time.workspace = true
 tracing.workspace = true
 
 near-primitives.workspace = true

--- a/chain/chain-primitives/src/error.rs
+++ b/chain/chain-primitives/src/error.rs
@@ -1,14 +1,11 @@
-use std::io;
-
-use chrono::DateTime;
-use chrono::Utc;
-
 use near_primitives::block::BlockValidityError;
 use near_primitives::challenge::{ChunkProofs, ChunkState};
 use near_primitives::errors::{EpochError, StorageError};
 use near_primitives::shard_layout::ShardLayoutError;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
 use near_primitives::types::{BlockHeight, EpochId, ShardId};
+use std::io;
+use time::OffsetDateTime as Utc;
 
 #[derive(thiserror::Error, Debug)]
 pub enum QueryError {
@@ -76,10 +73,10 @@ pub enum Error {
     ChunksMissing(Vec<ShardChunkHeader>),
     /// Block time is before parent block time.
     #[error("Invalid Block Time: block time {1} before previous {0}")]
-    InvalidBlockPastTime(DateTime<Utc>, DateTime<Utc>),
+    InvalidBlockPastTime(Utc, Utc),
     /// Block time is from too much in the future.
     #[error("Invalid Block Time: Too far in the future: {0}")]
-    InvalidBlockFutureTime(DateTime<Utc>),
+    InvalidBlockFutureTime(Utc),
     /// Block height is invalid (not previous + 1).
     #[error("Invalid Block Height {0}")]
     InvalidBlockHeight(BlockHeight),

--- a/chain/chain/src/block_processing_utils.rs
+++ b/chain/chain/src/block_processing_utils.rs
@@ -2,6 +2,7 @@ use crate::chain::BlockMissingChunks;
 use crate::near_chain_primitives::error::BlockKnownError::KnownInProcessing;
 use crate::orphan::OrphanMissingChunks;
 use crate::Provenance;
+use near_async::time::Instant;
 use near_primitives::block::Block;
 use near_primitives::challenge::{ChallengeBody, ChallengesResult};
 use near_primitives::hash::CryptoHash;
@@ -10,7 +11,6 @@ use near_primitives::types::ShardId;
 use once_cell::sync::OnceCell;
 use std::collections::HashMap;
 use std::sync::Arc;
-use std::time::Instant;
 
 /// Max number of blocks that can be in the pool at once.
 /// This number will likely never be hit unless there are many forks in the chain.

--- a/chain/chain/src/blocks_delay_tracker.rs
+++ b/chain/chain/src/blocks_delay_tracker.rs
@@ -1,9 +1,8 @@
-use chrono::DateTime;
+use near_async::time::{Clock, Instant, Utc};
 use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::block::{Block, Tip};
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::{ChunkHash, ShardChunkHeader};
-use near_primitives::static_clock::StaticClock;
 use near_primitives::types::{BlockHeight, ShardId};
 use near_primitives::views::{
     BlockProcessingInfo, BlockProcessingStatus, ChainProcessingInfo, ChunkProcessingInfo,
@@ -11,7 +10,6 @@ use near_primitives::views::{
 };
 use std::collections::{hash_map::Entry, BTreeMap, HashMap};
 use std::mem;
-use std::time::Instant;
 use tracing::error;
 
 use crate::{metrics, Chain, ChainStoreAccess};
@@ -25,8 +23,8 @@ const BLOCK_DELAY_TRACKING_COUNT: u64 = 50;
 /// the block already passes a few checks in ClientActor and in Client before it enters the chain
 /// code. For example, client actor checks that the block must be within head_height + BLOCK_HORIZON (500),
 /// that's why we know tracker at most tracks 550 blocks.
-#[derive(Debug, Default)]
 pub struct BlocksDelayTracker {
+    clock: Clock,
     // A block is added at the first time it was received, and
     // removed if it is too far from the chain head.
     blocks: HashMap<CryptoHash, BlockTrackingStats>,
@@ -45,7 +43,7 @@ pub struct BlocksDelayTracker {
 pub struct BlockTrackingStats {
     /// Timestamp when block was received.
     pub received_timestamp: Instant,
-    pub received_utc_timestamp: DateTime<chrono::Utc>,
+    pub received_utc_timestamp: Utc,
     /// Timestamp when block was put to the orphan pool, if it ever was
     pub orphaned_timestamp: Option<Instant>,
     /// Timestamp when block was put to the missing chunks pool
@@ -73,9 +71,9 @@ pub struct ChunkTrackingStats {
     pub shard_id: ShardId,
     pub prev_block_hash: CryptoHash,
     /// Timestamp of first time when we request for this chunk.
-    pub requested_timestamp: Option<DateTime<chrono::Utc>>,
+    pub requested_timestamp: Option<Utc>,
     /// Timestamp of when the node receives all information it needs for this chunk
-    pub completed_timestamp: Option<DateTime<chrono::Utc>>,
+    pub completed_timestamp: Option<Utc>,
 }
 
 impl ChunkTrackingStats {
@@ -109,7 +107,7 @@ impl ChunkTrackingStats {
             .ok();
         let request_duration = if let Some(requested_timestamp) = self.requested_timestamp {
             if let Some(completed_timestamp) = self.completed_timestamp {
-                Some((completed_timestamp - requested_timestamp).num_milliseconds() as u64)
+                Some((completed_timestamp - requested_timestamp).whole_milliseconds() as u64)
             } else {
                 None
             }
@@ -132,12 +130,18 @@ impl ChunkTrackingStats {
 }
 
 impl BlocksDelayTracker {
-    pub fn mark_block_received(
-        &mut self,
-        block: &Block,
-        timestamp: Instant,
-        utc_timestamp: DateTime<chrono::Utc>,
-    ) {
+    pub fn new(clock: Clock) -> Self {
+        Self {
+            clock,
+            blocks: HashMap::new(),
+            blocks_height_map: BTreeMap::new(),
+            chunks: HashMap::new(),
+            floating_chunks: HashMap::new(),
+            head_height: 0,
+        }
+    }
+
+    pub fn mark_block_received(&mut self, block: &Block) {
         let block_hash = block.header().hash();
 
         if let Entry::Vacant(entry) = self.blocks.entry(*block_hash) {
@@ -159,8 +163,8 @@ impl BlocksDelayTracker {
                 })
                 .collect();
             entry.insert(BlockTrackingStats {
-                received_timestamp: timestamp,
-                received_utc_timestamp: utc_timestamp,
+                received_timestamp: self.clock.now(),
+                received_utc_timestamp: self.clock.now_utc(),
                 orphaned_timestamp: None,
                 missing_chunks_timestamp: None,
                 removed_from_orphan_timestamp: None,
@@ -190,47 +194,39 @@ impl BlocksDelayTracker {
         }
     }
 
-    pub fn mark_block_orphaned(&mut self, block_hash: &CryptoHash, timestamp: Instant) {
+    pub fn mark_block_orphaned(&mut self, block_hash: &CryptoHash) {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
-            block_entry.orphaned_timestamp = Some(timestamp);
+            block_entry.orphaned_timestamp = Some(self.clock.now());
         } else {
             error!(target:"blocks_delay_tracker", "block {:?} was orphaned but was not marked received", block_hash);
         }
     }
 
-    pub fn mark_block_unorphaned(&mut self, block_hash: &CryptoHash, timestamp: Instant) {
+    pub fn mark_block_unorphaned(&mut self, block_hash: &CryptoHash) {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
-            block_entry.removed_from_orphan_timestamp = Some(timestamp);
+            block_entry.removed_from_orphan_timestamp = Some(self.clock.now());
         } else {
             error!(target:"blocks_delay_tracker", "block {:?} was unorphaned but was not marked received", block_hash);
         }
     }
 
-    pub fn mark_block_has_missing_chunks(&mut self, block_hash: &CryptoHash, timestamp: Instant) {
+    pub fn mark_block_has_missing_chunks(&mut self, block_hash: &CryptoHash) {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
-            block_entry.missing_chunks_timestamp = Some(timestamp);
+            block_entry.missing_chunks_timestamp = Some(self.clock.now());
         } else {
             error!(target:"blocks_delay_tracker", "block {:?} was marked as having missing chunks but was not marked received", block_hash);
         }
     }
 
-    pub fn mark_block_completed_missing_chunks(
-        &mut self,
-        block_hash: &CryptoHash,
-        timestamp: Instant,
-    ) {
+    pub fn mark_block_completed_missing_chunks(&mut self, block_hash: &CryptoHash) {
         if let Some(block_entry) = self.blocks.get_mut(block_hash) {
-            block_entry.removed_from_missing_chunks_timestamp = Some(timestamp);
+            block_entry.removed_from_missing_chunks_timestamp = Some(self.clock.now());
         } else {
             error!(target:"blocks_delay_tracker", "block {:?} was marked as having no missing chunks but was not marked received", block_hash);
         }
     }
 
-    pub fn mark_chunk_completed(
-        &mut self,
-        chunk_header: &ShardChunkHeader,
-        timestamp: DateTime<chrono::Utc>,
-    ) {
+    pub fn mark_chunk_completed(&mut self, chunk_header: &ShardChunkHeader) {
         let chunk_hash = chunk_header.chunk_hash();
         self.chunks
             .entry(chunk_hash.clone())
@@ -239,14 +235,10 @@ impl BlocksDelayTracker {
                 ChunkTrackingStats::new(chunk_header)
             })
             .completed_timestamp
-            .get_or_insert(timestamp);
+            .get_or_insert(self.clock.now_utc());
     }
 
-    pub fn mark_chunk_requested(
-        &mut self,
-        chunk_header: &ShardChunkHeader,
-        timestamp: DateTime<chrono::Utc>,
-    ) {
+    pub fn mark_chunk_requested(&mut self, chunk_header: &ShardChunkHeader) {
         let chunk_hash = chunk_header.chunk_hash();
         self.chunks
             .entry(chunk_hash.clone())
@@ -255,7 +247,7 @@ impl BlocksDelayTracker {
                 ChunkTrackingStats::new(chunk_header)
             })
             .requested_timestamp
-            .get_or_insert(timestamp);
+            .get_or_insert(self.clock.now_utc());
     }
 
     fn update_head(&mut self, head_height: BlockHeight) {
@@ -298,7 +290,7 @@ impl BlocksDelayTracker {
 
     pub fn finish_block_processing(&mut self, block_hash: &CryptoHash, new_head: Option<Tip>) {
         if let Some(processed_block) = self.blocks.get_mut(&block_hash) {
-            processed_block.processed_timestamp = Some(StaticClock::instant());
+            processed_block.processed_timestamp = Some(self.clock.now());
         }
         // To get around the rust reference scope check
         if let Some(processed_block) = self.blocks.get(&block_hash) {
@@ -320,8 +312,7 @@ impl BlocksDelayTracker {
     fn update_block_metrics(&self, block: &BlockTrackingStats) {
         if let Some(start) = block.orphaned_timestamp {
             if let Some(end) = block.removed_from_orphan_timestamp {
-                metrics::BLOCK_ORPHANED_DELAY
-                    .observe(end.saturating_duration_since(start).as_secs_f64());
+                metrics::BLOCK_ORPHANED_DELAY.observe((end - start).as_seconds_f64().max(0.0));
             }
         } else {
             metrics::BLOCK_ORPHANED_DELAY.observe(0.);
@@ -329,7 +320,7 @@ impl BlocksDelayTracker {
         if let Some(start) = block.missing_chunks_timestamp {
             if let Some(end) = block.removed_from_missing_chunks_timestamp {
                 metrics::BLOCK_MISSING_CHUNKS_DELAY
-                    .observe(end.saturating_duration_since(start).as_secs_f64());
+                    .observe((end - start).as_seconds_f64().max(0.0));
             }
         } else {
             metrics::BLOCK_MISSING_CHUNKS_DELAY.observe(0.);
@@ -343,7 +334,7 @@ impl BlocksDelayTracker {
             if let Some(chunk_received) = chunk.completed_timestamp {
                 metrics::CHUNK_RECEIVED_DELAY
                     .with_label_values(&[&shard_id.to_string()])
-                    .observe((chunk_received - chunk_requested).num_milliseconds() as f64 / 1000.);
+                    .observe((chunk_received - chunk_requested).as_seconds_f64());
             }
         }
     }
@@ -369,30 +360,29 @@ impl BlocksDelayTracker {
                     }
                 })
                 .collect();
-            let now = StaticClock::instant();
+            let now = self.clock.now();
             let block_status = chain.get_block_status(block_hash, block_stats);
-            let in_progress_ms = block_stats
-                .processed_timestamp
-                .unwrap_or(now)
-                .checked_duration_since(block_stats.received_timestamp)
-                .map(|x| x.as_millis())
-                .unwrap_or_default();
+            let in_progress_ms = (block_stats.processed_timestamp.unwrap_or(now)
+                - block_stats.received_timestamp)
+                .whole_milliseconds()
+                .max(0) as u128;
             let orphaned_ms = if let Some(orphaned_time) = block_stats.orphaned_timestamp {
-                block_stats
-                    .removed_from_orphan_timestamp
-                    .unwrap_or(now)
-                    .checked_duration_since(orphaned_time)
-                    .map(|x| x.as_millis())
+                Some(
+                    (block_stats.removed_from_orphan_timestamp.unwrap_or(now) - orphaned_time)
+                        .whole_milliseconds()
+                        .max(0) as u128,
+                )
             } else {
                 None
             };
             let missing_chunks_ms =
                 if let Some(missing_chunks_time) = block_stats.missing_chunks_timestamp {
-                    block_stats
-                        .removed_from_missing_chunks_timestamp
-                        .unwrap_or(now)
-                        .checked_duration_since(missing_chunks_time)
-                        .map(|x| x.as_millis())
+                    Some(
+                        (block_stats.removed_from_missing_chunks_timestamp.unwrap_or(now)
+                            - missing_chunks_time)
+                            .whole_milliseconds()
+                            .max(0) as u128,
+                    )
                 } else {
                     None
                 };

--- a/chain/chain/src/chain.rs
+++ b/chain/chain/src/chain.rs
@@ -34,10 +34,10 @@ use crate::{
 };
 use crate::{metrics, DoomslugThresholdMode};
 use borsh::BorshDeserialize;
-use chrono::Duration;
 use crossbeam_channel::{unbounded, Receiver, Sender};
 use itertools::Itertools;
 use lru::LruCache;
+use near_async::time::{Clock, Duration, Instant};
 use near_chain_configs::{MutableConfigValue, ReshardingConfig, ReshardingHandle};
 #[cfg(feature = "new_epoch_sync")]
 use near_chain_primitives::error::epoch_sync::EpochSyncInfoError;
@@ -74,7 +74,6 @@ use near_primitives::state_sync::{
     get_num_state_parts, BitArray, CachedParts, ReceiptProofResponse, RootProof,
     ShardStateSyncResponseHeader, ShardStateSyncResponseHeaderV2, StateHeaderKey, StatePartKey,
 };
-use near_primitives::static_clock::StaticClock;
 use near_primitives::transaction::{ExecutionOutcomeWithIdAndProof, SignedTransaction};
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{
@@ -100,7 +99,6 @@ use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::{Debug, Formatter};
 use std::sync::Arc;
-use std::time::Instant;
 use tracing::{debug, debug_span, error, info, warn, Span};
 
 /// The size of the invalid_blocks in-memory pool
@@ -218,6 +216,7 @@ type BlockApplyChunksResult = (CryptoHash, Vec<(ShardId, Result<ShardUpdateResul
 /// Facade to the blockchain block processing and storage.
 /// Provides current view on the state according to the chain state.
 pub struct Chain {
+    pub(crate) clock: Clock,
     chain_store: ChainStore,
     pub epoch_manager: Arc<dyn EpochManagerAdapter>,
     pub shard_tracker: ShardTracker,
@@ -337,6 +336,7 @@ impl Chain {
         doomslug_threshold_mode: DoomslugThresholdMode,
         save_trie_changes: bool,
     ) -> Result<Chain, Error> {
+        let clock = Clock::real(); // TODO: make this a parameter
         let store = runtime_adapter.store();
         let chain_store = ChainStore::new(store.clone(), chain_genesis.height, save_trie_changes);
         let genesis = Self::make_genesis_block(
@@ -346,6 +346,7 @@ impl Chain {
         )?;
         let (sc, rc) = unbounded();
         Ok(Chain {
+            clock: clock.clone(),
             chain_store,
             epoch_manager,
             shard_tracker,
@@ -358,10 +359,10 @@ impl Chain {
             epoch_length: chain_genesis.epoch_length,
             block_economics_config: BlockEconomicsConfig::from(chain_genesis),
             doomslug_threshold_mode,
-            blocks_delay_tracker: BlocksDelayTracker::default(),
+            blocks_delay_tracker: BlocksDelayTracker::new(clock.clone()),
             apply_chunks_sender: sc,
             apply_chunks_receiver: rc,
-            last_time_head_updated: StaticClock::instant(),
+            last_time_head_updated: clock.now(),
             invalid_blocks: LruCache::new(INVALID_CHUNKS_POOL_SIZE),
             pending_state_patch: Default::default(),
             requested_state_parts: StateRequestTracker::new(),
@@ -383,7 +384,8 @@ impl Chain {
         chain_config: ChainConfig,
         snapshot_callbacks: Option<SnapshotCallbacks>,
     ) -> Result<Chain, Error> {
-        // Get runtime initial state and create genesis block out of it.
+        let clock = Clock::real(); // TODO: make this a parameter
+                                   // Get runtime initial state and create genesis block out of it.
         let state_roots = get_genesis_state_roots(runtime_adapter.store())?
             .expect("genesis should be initialized.");
         let mut chain_store = ChainStore::new(
@@ -509,7 +511,7 @@ impl Chain {
         let block_header = chain_store.get_block_header(&block_head.last_block_hash)?;
         metrics::BLOCK_ORDINAL_HEAD.set(block_header.block_ordinal() as i64);
         metrics::HEADER_HEAD_HEIGHT.set(header_head.height as i64);
-        metrics::BOOT_TIME_SECONDS.set(StaticClock::utc().timestamp());
+        metrics::BOOT_TIME_SECONDS.set(clock.now_utc().unix_timestamp());
 
         metrics::TAIL_HEIGHT.set(chain_store.tail()? as i64);
         metrics::CHUNK_TAIL_HEIGHT.set(chain_store.chunk_tail()? as i64);
@@ -519,6 +521,7 @@ impl Chain {
         // of blocks_in_processing, which is set to 5 now.
         let (sc, rc) = unbounded();
         Ok(Chain {
+            clock: clock.clone(),
             chain_store,
             epoch_manager,
             shard_tracker,
@@ -532,10 +535,10 @@ impl Chain {
             epoch_length: chain_genesis.epoch_length,
             block_economics_config: BlockEconomicsConfig::from(chain_genesis),
             doomslug_threshold_mode,
-            blocks_delay_tracker: Default::default(),
+            blocks_delay_tracker: BlocksDelayTracker::new(clock.clone()),
             apply_chunks_sender: sc,
             apply_chunks_receiver: rc,
-            last_time_head_updated: StaticClock::instant(),
+            last_time_head_updated: clock.now(),
             pending_state_patch: Default::default(),
             requested_state_parts: StateRequestTracker::new(),
             snapshot_callbacks,
@@ -825,7 +828,10 @@ impl Chain {
         challenges: &mut Vec<ChallengeBody>,
     ) -> Result<(), Error> {
         // Refuse blocks from the too distant future.
-        if header.timestamp() > StaticClock::utc() + Duration::seconds(ACCEPTABLE_TIME_DIFFERENCE) {
+        if header.raw_timestamp()
+            > (self.clock.now_utc() + Duration::seconds(ACCEPTABLE_TIME_DIFFERENCE))
+                .unix_timestamp() as u64
+        {
             return Err(Error::InvalidBlockFutureTime(header.timestamp()));
         }
 
@@ -1321,7 +1327,7 @@ impl Chain {
     ) -> Result<(), Error> {
         let _span =
             debug_span!(target: "chain", "start_process_block_async", ?provenance).entered();
-        let block_received_time = StaticClock::instant();
+        let block_received_time = self.clock.now();
         metrics::BLOCK_PROCESSING_ATTEMPTS_TOTAL.inc();
 
         let block_height = block.header().height();
@@ -1626,14 +1632,8 @@ impl Chain {
                                 false
                             };
 
-                            let time = StaticClock::instant();
-                            self.blocks_delay_tracker.mark_block_orphaned(block.hash(), time);
-                            self.save_orphan(
-                                block,
-                                provenance,
-                                Some(time),
-                                requested_missing_chunks,
-                            );
+                            self.blocks_delay_tracker.mark_block_orphaned(block.hash());
+                            self.save_orphan(block, provenance, requested_missing_chunks);
                         }
                     }
                     Error::ChunksMissing(missing_chunks) => {
@@ -1644,9 +1644,8 @@ impl Chain {
                             prev_hash: *block.header().prev_hash(),
                             missing_chunks: missing_chunks.clone(),
                         });
-                        let time = StaticClock::instant();
-                        self.blocks_delay_tracker.mark_block_has_missing_chunks(block.hash(), time);
-                        let orphan = Orphan { block, provenance, added: time };
+                        self.blocks_delay_tracker.mark_block_has_missing_chunks(block.hash());
+                        let orphan = Orphan { block, provenance, added: self.clock.now() };
                         self.blocks_with_missing_chunks
                             .add_block_with_missing_chunks(orphan, missing_chunk_hashes.clone());
                         debug!(
@@ -1856,19 +1855,20 @@ impl Chain {
             metrics::VALIDATOR_AMOUNT_STAKED.set(i64::try_from(stake).unwrap_or(i64::MAX));
             metrics::VALIDATOR_ACTIVE_TOTAL.set(i64::try_from(count).unwrap_or(i64::MAX));
 
-            self.last_time_head_updated = StaticClock::instant();
+            self.last_time_head_updated = self.clock.now();
         };
 
         metrics::BLOCK_PROCESSED_TOTAL.inc();
-        metrics::BLOCK_PROCESSING_TIME.observe(
-            StaticClock::instant()
-                .saturating_duration_since(block_start_processing_time)
-                .as_secs_f64(),
-        );
+        metrics::BLOCK_PROCESSING_TIME
+            .observe((self.clock.now() - block_start_processing_time).as_seconds_f64().max(0.0));
         self.blocks_delay_tracker.finish_block_processing(&block_hash, new_head.clone());
 
         timer.observe_duration();
-        let _timer = CryptoHashTimer::new_with_start(*block.hash(), block_start_processing_time);
+        let _timer = CryptoHashTimer::new_with_start(
+            self.clock.clone(),
+            *block.hash(),
+            block_start_processing_time,
+        );
 
         self.check_orphans(
             me,
@@ -2184,7 +2184,6 @@ impl Chain {
         for block in blocks {
             let block_hash = *block.block.header().hash();
             let height = block.block.header().height();
-            let time = StaticClock::instant();
             let res = self.start_process_block_async(
                 me,
                 block.block,
@@ -2195,8 +2194,7 @@ impl Chain {
             match res {
                 Ok(_) => {
                     debug!(target: "chain", %block_hash, height, "Accepted block with missing chunks");
-                    self.blocks_delay_tracker
-                        .mark_block_completed_missing_chunks(&block_hash, time);
+                    self.blocks_delay_tracker.mark_block_completed_missing_chunks(&block_hash);
                 }
                 Err(_) => {
                     debug!(target: "chain", %block_hash, height, "Declined block with missing chunks is declined.");
@@ -2463,7 +2461,7 @@ impl Chain {
             )
             .log_storage_error("obtain_state_part fail")?;
 
-        let elapsed_ms = current_time.elapsed().as_millis();
+        let elapsed_ms = current_time.elapsed().whole_milliseconds().max(0) as u128;
         self.requested_state_parts
             .save_state_part_elapsed(&sync_hash, &shard_id, &part_id, elapsed_ms);
 

--- a/chain/chain/src/crypto_hash_timer.rs
+++ b/chain/chain/src/crypto_hash_timer.rs
@@ -1,11 +1,8 @@
 use lru::LruCache;
-use near_primitives::{hash::CryptoHash, static_clock::StaticClock};
-use std::{
-    sync::Mutex,
-    time::{Duration, Instant},
-};
-
+use near_async::time::{Clock, Duration, Instant};
+use near_primitives::hash::CryptoHash;
 use once_cell::sync::Lazy;
+use std::sync::Mutex;
 
 // Cache with the mapping from CryptoHash (blocks, chunks) to the number milliseconds that it took to process them.
 // Used only for debugging purposes.
@@ -25,16 +22,17 @@ static CRYPTO_HASH_TIMER_RESULTS: Lazy<Mutex<LruCache<CryptoHash, Duration>>> =
 /// ```
 #[must_use]
 pub struct CryptoHashTimer {
+    clock: Clock,
     key: CryptoHash,
     start: Instant,
 }
 
 impl CryptoHashTimer {
-    pub fn new(key: CryptoHash) -> Self {
-        Self::new_with_start(key, StaticClock::instant())
+    pub fn new(clock: Clock, key: CryptoHash) -> Self {
+        Self::new_with_start(clock.clone(), key, clock.now())
     }
-    pub fn new_with_start(key: CryptoHash, start: Instant) -> Self {
-        CryptoHashTimer { key, start }
+    pub fn new_with_start(clock: Clock, key: CryptoHash, start: Instant) -> Self {
+        CryptoHashTimer { clock, key, start }
     }
     pub fn get_timer_value(key: CryptoHash) -> Option<Duration> {
         CRYPTO_HASH_TIMER_RESULTS.lock().unwrap().get(&key).cloned()
@@ -43,33 +41,44 @@ impl CryptoHashTimer {
 
 impl Drop for CryptoHashTimer {
     fn drop(&mut self) {
-        let time_passed = StaticClock::instant() - self.start;
+        let time_passed = self.clock.now() - self.start;
         let mut guard_ = CRYPTO_HASH_TIMER_RESULTS.lock().unwrap();
         let previous = guard_.get(&self.key).copied().unwrap_or_default();
         guard_.put(self.key, time_passed + previous);
     }
 }
 
-#[test]
-fn test_crypto_hash_timer() {
-    let crypto_hash: CryptoHash = "s3N6V7CNAN2Eg6vfivMVHR4hbMZeh72fTmYbrC6dXBT".parse().unwrap();
-    // Timer should be missing.
-    assert_eq!(CryptoHashTimer::get_timer_value(crypto_hash), None);
-    let mock_clock_guard = near_primitives::static_clock::MockClockGuard::default();
-    let start_time = Instant::now();
-    mock_clock_guard.add_instant(start_time);
-    mock_clock_guard.add_instant(start_time + std::time::Duration::from_secs(1));
-    {
-        let _timer = CryptoHashTimer::new(crypto_hash);
+#[cfg(test)]
+mod tests {
+    use crate::crypto_hash_timer::CryptoHashTimer;
+    use near_async::time::{Duration, FakeClock, Utc};
+    use near_primitives::hash::CryptoHash;
+
+    #[test]
+    fn test_crypto_hash_timer() {
+        let crypto_hash: CryptoHash =
+            "s3N6V7CNAN2Eg6vfivMVHR4hbMZeh72fTmYbrC6dXBT".parse().unwrap();
+        // Timer should be missing.
+        let clock = FakeClock::new(Utc::UNIX_EPOCH);
+        assert_eq!(CryptoHashTimer::get_timer_value(crypto_hash), None);
+        {
+            let _timer = CryptoHashTimer::new(clock.clock(), crypto_hash);
+            clock.advance(Duration::seconds(1));
+        }
+        // Timer should show exactly 1 second (1000 ms).
+        assert_eq!(
+            CryptoHashTimer::get_timer_value(crypto_hash),
+            Some(Duration::milliseconds(1000))
+        );
+
+        {
+            let _timer = CryptoHashTimer::new(clock.clock(), crypto_hash);
+            clock.advance(Duration::seconds(2));
+        }
+        // Now we run the second time (with the same hash) - so the counter should show 3 seconds.
+        assert_eq!(
+            CryptoHashTimer::get_timer_value(crypto_hash),
+            Some(Duration::milliseconds(3000))
+        );
     }
-    // Timer should show exactly 1 second (1000 ms).
-    assert_eq!(CryptoHashTimer::get_timer_value(crypto_hash), Some(Duration::from_millis(1000)));
-    let start_time = Instant::now();
-    mock_clock_guard.add_instant(start_time);
-    mock_clock_guard.add_instant(start_time + std::time::Duration::from_secs(2));
-    {
-        let _timer = CryptoHashTimer::new(crypto_hash);
-    }
-    // Now we run the second time (with the same hash) - so the counter should show 3 seconds.
-    assert_eq!(CryptoHashTimer::get_timer_value(crypto_hash), Some(Duration::from_millis(3000)));
 }

--- a/chain/chain/src/doomslug.rs
+++ b/chain/chain/src/doomslug.rs
@@ -1,16 +1,14 @@
-use std::collections::{HashMap, VecDeque};
-use std::sync::Arc;
-use std::time::{Duration, Instant};
-
 use crate::doomslug::trackable::TrackableBlockHeightValue;
 use crate::metrics;
+use near_async::time::{Clock, Duration, Instant, Utc};
 use near_client_primitives::debug::{ApprovalAtHeightStatus, ApprovalHistoryEntry};
 use near_crypto::Signature;
 use near_primitives::block::{Approval, ApprovalInner};
 use near_primitives::hash::CryptoHash;
-use near_primitives::static_clock::StaticClock;
 use near_primitives::types::{AccountId, ApprovalStake, Balance, BlockHeight, BlockHeightDelta};
 use near_primitives::validator_signer::ValidatorSigner;
+use std::collections::{HashMap, VecDeque};
+use std::sync::Arc;
 use tracing::{debug, debug_span, field, info};
 
 /// Have that many iterations in the timer instead of `loop` to prevent potential bugs from blocking
@@ -64,7 +62,8 @@ struct DoomslugTip {
 }
 
 struct DoomslugApprovalsTracker {
-    witness: HashMap<AccountId, (Approval, chrono::DateTime<chrono::Utc>)>,
+    clock: Clock,
+    witness: HashMap<AccountId, (Approval, Utc)>,
     account_id_to_stakes: HashMap<AccountId, (Balance, Balance)>,
     total_stake_this_epoch: Balance,
     approved_stake_this_epoch: Balance,
@@ -113,6 +112,7 @@ mod trackable {
 /// responsible for ensuring that only approvals for proper account_ids with valid signatures are
 /// provided.
 struct DoomslugApprovalsTrackersAtHeight {
+    clock: Clock,
     approval_trackers: HashMap<ApprovalInner, DoomslugApprovalsTracker>,
     last_approval_per_account: HashMap<AccountId, ApprovalInner>,
 }
@@ -121,6 +121,7 @@ struct DoomslugApprovalsTrackersAtHeight {
 /// happens via `PersistentDoomslug` struct. The split is to simplify testing of the logic separate
 /// from the chain.
 pub struct Doomslug {
+    clock: Clock,
     approval_tracking: HashMap<BlockHeight, DoomslugApprovalsTrackersAtHeight>,
     /// Largest target height for which we issued an approval
     largest_target_height: TrackableBlockHeightValue,
@@ -163,6 +164,7 @@ impl DoomslugTimer {
 
 impl DoomslugApprovalsTracker {
     fn new(
+        clock: Clock,
         account_id_to_stakes: HashMap<AccountId, (Balance, Balance)>,
         threshold_mode: DoomslugThresholdMode,
     ) -> Self {
@@ -170,6 +172,7 @@ impl DoomslugApprovalsTracker {
         let total_stake_next_epoch = account_id_to_stakes.values().map(|(_, x)| x).sum::<Balance>();
 
         DoomslugApprovalsTracker {
+            clock,
             witness: Default::default(),
             account_id_to_stakes,
             total_stake_this_epoch,
@@ -191,15 +194,11 @@ impl DoomslugApprovalsTracker {
     ///
     /// # Returns
     /// Whether the block is ready to be produced
-    fn process_approval(
-        &mut self,
-        now: Instant,
-        approval: &Approval,
-    ) -> DoomslugBlockProductionReadiness {
+    fn process_approval(&mut self, approval: &Approval) -> DoomslugBlockProductionReadiness {
         let mut increment_approved_stake = false;
         self.witness.entry(approval.account_id.clone()).or_insert_with(|| {
             increment_approved_stake = true;
-            (approval.clone(), chrono::Utc::now())
+            (approval.clone(), self.clock.now_utc())
         });
 
         if increment_approved_stake {
@@ -210,7 +209,7 @@ impl DoomslugApprovalsTracker {
 
         // We call to `get_block_production_readiness` here so that if the number of approvals crossed
         // the threshold, the timer for block production starts.
-        self.get_block_production_readiness(now)
+        self.get_block_production_readiness()
     }
 
     /// Withdraws an approval. This happens if a newer approval for the same `target_height` comes
@@ -236,14 +235,14 @@ impl DoomslugApprovalsTracker {
     /// `NotReady` if the block doesn't have enough approvals yet to cross the threshold
     /// `ReadySince` if the block has enough approvals to pass the threshold, and since when it
     ///     does
-    fn get_block_production_readiness(&mut self, now: Instant) -> DoomslugBlockProductionReadiness {
+    fn get_block_production_readiness(&mut self) -> DoomslugBlockProductionReadiness {
         if (self.approved_stake_this_epoch > self.total_stake_this_epoch * 2 / 3
             && (self.approved_stake_next_epoch > self.total_stake_next_epoch * 2 / 3
                 || self.total_stake_next_epoch == 0))
             || self.threshold_mode == DoomslugThresholdMode::NoApprovals
         {
             if self.time_passed_threshold == None {
-                self.time_passed_threshold = Some(now);
+                self.time_passed_threshold = Some(self.clock.now());
             }
             DoomslugBlockProductionReadiness::ReadySince(self.time_passed_threshold.unwrap())
         } else {
@@ -252,7 +251,7 @@ impl DoomslugApprovalsTracker {
     }
 
     // Get witnesses together with their arrival time.
-    fn get_witnesses(&self) -> Vec<(AccountId, chrono::DateTime<chrono::Utc>)> {
+    fn get_witnesses(&self) -> Vec<(AccountId, Utc)> {
         self.witness
             .iter()
             .map(|(key, (_, arrival_time))| (key.clone(), *arrival_time))
@@ -261,8 +260,8 @@ impl DoomslugApprovalsTracker {
 }
 
 impl DoomslugApprovalsTrackersAtHeight {
-    fn new() -> Self {
-        Self { approval_trackers: HashMap::new(), last_approval_per_account: HashMap::new() }
+    fn new(clock: Clock) -> Self {
+        Self { clock, approval_trackers: HashMap::new(), last_approval_per_account: HashMap::new() }
     }
 
     /// This method is a wrapper around `DoomslugApprovalsTracker::process_approval`, see comment
@@ -272,7 +271,6 @@ impl DoomslugApprovalsTrackersAtHeight {
     /// corresponding tracker, and associate the new approval with the account.
     ///
     /// # Arguments
-    /// * `now`      - the current timestamp
     /// * `approval` - the approval to be processed
     /// * `stakes`   - all the stakes of all the block producers in the current epoch
     /// * `threshold_mode` - how many approvals are needed to produce a block. Is used to compute
@@ -282,7 +280,6 @@ impl DoomslugApprovalsTrackersAtHeight {
     /// Same as `DoomslugApprovalsTracker::process_approval`
     fn process_approval(
         &mut self,
-        now: Instant,
         approval: &Approval,
         stakes: &[(ApprovalStake, bool)],
         threshold_mode: DoomslugThresholdMode,
@@ -322,8 +319,14 @@ impl DoomslugApprovalsTrackersAtHeight {
         self.last_approval_per_account.insert(approval.account_id.clone(), approval.inner.clone());
         self.approval_trackers
             .entry(approval.inner.clone())
-            .or_insert_with(|| DoomslugApprovalsTracker::new(account_id_to_stakes, threshold_mode))
-            .process_approval(now, approval)
+            .or_insert_with(|| {
+                DoomslugApprovalsTracker::new(
+                    self.clock.clone(),
+                    account_id_to_stakes,
+                    threshold_mode,
+                )
+            })
+            .process_approval(approval)
     }
 
     /// Returns the current approvals status for the trackers at this height.
@@ -345,17 +348,14 @@ impl DoomslugApprovalsTrackersAtHeight {
             .iter()
             .filter_map(|(_, tracker)| tracker.time_passed_threshold)
             .min()
-            .map(|ts| {
-                chrono::Utc::now()
-                    - chrono::Duration::from_std(ts.elapsed())
-                        .unwrap_or_else(|_| chrono::Duration::days(1))
-            });
+            .map(|ts| self.clock.now_utc() - (self.clock.now() - ts));
         ApprovalAtHeightStatus { approvals, ready_at: threshold_approval }
     }
 }
 
 impl Doomslug {
     pub fn new(
+        clock: Clock,
         largest_target_height: BlockHeight,
         endorsement_delay: Duration,
         min_delay: Duration,
@@ -365,6 +365,7 @@ impl Doomslug {
         threshold_mode: DoomslugThresholdMode,
     ) -> Self {
         Doomslug {
+            clock: clock.clone(),
             approval_tracking: HashMap::new(),
             largest_target_height: TrackableBlockHeightValue::new(
                 largest_target_height,
@@ -382,8 +383,8 @@ impl Doomslug {
             tip: DoomslugTip { block_hash: CryptoHash::default(), height: 0 },
             endorsement_pending: false,
             timer: DoomslugTimer {
-                started: StaticClock::instant(),
-                last_endorsement_sent: StaticClock::instant(),
+                started: clock.now(),
+                last_endorsement_sent: clock.now(),
                 height: 0,
                 endorsement_delay,
                 min_delay,
@@ -463,7 +464,8 @@ impl Doomslug {
     /// A vector of approvals that need to be sent to other block producers as a result of processing
     /// the timers
     #[must_use]
-    pub fn process_timer(&mut self, cur_time: Instant) -> Vec<Approval> {
+    pub fn process_timer(&mut self) -> Vec<Approval> {
+        let now = self.clock.now();
         let mut ret = vec![];
         for _ in 0..MAX_TIMER_ITERS {
             let skip_delay = self
@@ -478,7 +480,7 @@ impl Doomslug {
             let tip_height = self.tip.height;
 
             if self.endorsement_pending
-                && cur_time >= self.timer.last_endorsement_sent + self.timer.endorsement_delay
+                && now >= self.timer.last_endorsement_sent + self.timer.endorsement_delay
             {
                 if tip_height >= self.largest_target_height.get() {
                     self.largest_target_height.set(tip_height + 1);
@@ -493,17 +495,19 @@ impl Doomslug {
                             .timer
                             .last_endorsement_sent
                             .elapsed()
-                            .as_millis() as u64,
-                        expected_delay_millis: self.timer.endorsement_delay.as_millis() as u64,
-                        approval_creation_time: chrono::Utc::now(),
+                            .whole_milliseconds()
+                            as u64,
+                        expected_delay_millis: self.timer.endorsement_delay.whole_milliseconds()
+                            as u64,
+                        approval_creation_time: self.clock.now_utc(),
                     });
                 }
 
-                self.timer.last_endorsement_sent = cur_time;
+                self.timer.last_endorsement_sent = now;
                 self.endorsement_pending = false;
             }
 
-            if cur_time >= self.timer.started + skip_delay {
+            if now >= self.timer.started + skip_delay {
                 debug_assert!(!self.endorsement_pending);
 
                 self.largest_target_height
@@ -515,9 +519,10 @@ impl Doomslug {
                 self.update_history(ApprovalHistoryEntry {
                     parent_height: tip_height,
                     target_height: self.timer.height + 1,
-                    timer_started_ago_millis: self.timer.started.elapsed().as_millis() as u64,
-                    expected_delay_millis: skip_delay.as_millis() as u64,
-                    approval_creation_time: chrono::Utc::now(),
+                    timer_started_ago_millis: self.timer.started.elapsed().whole_milliseconds()
+                        as u64,
+                    expected_delay_millis: skip_delay.whole_milliseconds() as u64,
+                    approval_creation_time: self.clock.now_utc(),
                 });
 
                 // Restart the timer
@@ -581,7 +586,7 @@ impl Doomslug {
         prev_hash: &CryptoHash,
         parent_height: BlockHeight,
         target_height: BlockHeight,
-    ) -> HashMap<AccountId, (Approval, chrono::DateTime<chrono::Utc>)> {
+    ) -> HashMap<AccountId, (Approval, Utc)> {
         let hash_or_height = ApprovalInner::new(prev_hash, parent_height, target_height);
         if let Some(approval_trackers_at_height) = self.approval_tracking.get(&target_height) {
             let approvals_tracker =
@@ -598,13 +603,11 @@ impl Doomslug {
     /// Updates the current tip of the chain. Restarts the timer accordingly.
     ///
     /// # Arguments
-    /// * `now`            - current time. Doesn't call to `Utc::now()` directly to simplify testing
     /// * `block_hash`     - the hash of the new tip
     /// * `height`         - the height of the tip
     /// * `last_ds_final_height` - last height at which a block in this chain has doomslug finality
     pub fn set_tip(
         &mut self,
-        now: Instant,
         block_hash: CryptoHash,
         height: BlockHeight,
         last_final_height: BlockHeight,
@@ -614,7 +617,7 @@ impl Doomslug {
 
         self.largest_final_height.set(last_final_height);
         self.timer.height = height + 1;
-        self.timer.started = now;
+        self.timer.started = self.clock.now();
 
         self.approval_tracking.retain(|h, _| {
             *h > height.saturating_sub(MAX_HEIGHTS_BEFORE_TO_STORE_APPROVALS)
@@ -630,7 +633,6 @@ impl Doomslug {
     #[must_use]
     fn on_approval_message_internal(
         &mut self,
-        now: Instant,
         approval: &Approval,
         stakes: &[(ApprovalStake, bool)],
     ) -> DoomslugBlockProductionReadiness {
@@ -638,8 +640,8 @@ impl Doomslug {
         let ret = self
             .approval_tracking
             .entry(approval.target_height)
-            .or_insert_with(|| DoomslugApprovalsTrackersAtHeight::new())
-            .process_approval(now, approval, stakes, threshold_mode);
+            .or_insert_with(|| DoomslugApprovalsTrackersAtHeight::new(self.clock.clone()))
+            .process_approval(approval, stakes, threshold_mode);
 
         if approval.target_height > self.largest_approval_height.get() {
             self.largest_approval_height.set(approval.target_height);
@@ -655,19 +657,14 @@ impl Doomslug {
     }
 
     /// Processes single approval
-    pub fn on_approval_message(
-        &mut self,
-        now: Instant,
-        approval: &Approval,
-        stakes: &[(ApprovalStake, bool)],
-    ) {
+    pub fn on_approval_message(&mut self, approval: &Approval, stakes: &[(ApprovalStake, bool)]) {
         if approval.target_height < self.tip.height
             || approval.target_height > self.tip.height + MAX_HEIGHTS_AHEAD_TO_STORE_APPROVALS
         {
             return;
         }
 
-        let _ = self.on_approval_message_internal(now, approval, stakes);
+        let _ = self.on_approval_message_internal(approval, stakes);
     }
 
     /// Gets the current status of approvals for a given height.
@@ -695,7 +692,6 @@ impl Doomslug {
     #[must_use]
     pub fn ready_to_produce_block(
         &mut self,
-        now: Instant,
         target_height: BlockHeight,
         has_enough_chunks: bool,
         log_block_production_info: bool,
@@ -709,19 +705,18 @@ impl Doomslug {
             ready_to_produce_block = field::Empty,
             need_to_wait = field::Empty)
         .entered();
+        let now = self.clock.now();
         let hash_or_height =
             ApprovalInner::new(&self.tip.block_hash, self.tip.height, target_height);
         if let Some(approval_trackers_at_height) = self.approval_tracking.get_mut(&target_height) {
             if let Some(approval_tracker) =
                 approval_trackers_at_height.approval_trackers.get_mut(&hash_or_height)
             {
-                let block_production_readiness =
-                    approval_tracker.get_block_production_readiness(now);
-                match block_production_readiness {
+                match approval_tracker.get_block_production_readiness() {
                     DoomslugBlockProductionReadiness::NotReady => false,
                     DoomslugBlockProductionReadiness::ReadySince(when) => {
-                        let enough_approvals_for = now.saturating_duration_since(when);
-                        span.record("enough_approvals_for", enough_approvals_for.as_secs_f64());
+                        let enough_approvals_for = now - when;
+                        span.record("enough_approvals_for", enough_approvals_for.as_seconds_f64());
                         span.record("ready_to_produce_block", true);
                         if has_enough_chunks {
                             if log_block_production_info {
@@ -750,7 +745,7 @@ impl Doomslug {
                                     info!(
                                         target: "doomslug",
                                         target_height,
-                                        need_to_wait_for = ?(when + delay).saturating_duration_since(now),
+                                        need_to_wait_for = ?(when + delay - now),
                                         ?enough_approvals_for,
                                         "not ready to produce block, need to wait");
                                 }
@@ -772,51 +767,51 @@ impl Doomslug {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-    use std::time::Duration;
-
-    use near_crypto::{KeyType, SecretKey};
-    use near_primitives::block::{Approval, ApprovalInner};
-    use near_primitives::hash::hash;
-    use near_primitives::static_clock::StaticClock;
-    use near_primitives::test_utils::create_test_signer;
-    use near_primitives::types::ApprovalStake;
-
     use crate::doomslug::{
         DoomslugApprovalsTrackersAtHeight, DoomslugBlockProductionReadiness, DoomslugThresholdMode,
     };
     use crate::Doomslug;
+    use near_async::time::{Duration, FakeClock, Utc};
+    use near_crypto::{KeyType, SecretKey};
+    use near_primitives::block::{Approval, ApprovalInner};
+    use near_primitives::hash::hash;
+    use near_primitives::test_utils::create_test_signer;
+    use near_primitives::types::ApprovalStake;
+    use std::sync::Arc;
 
     #[test]
     fn test_endorsements_and_skips_basic() {
+        let clock = FakeClock::new(Utc::UNIX_EPOCH);
         let mut ds = Doomslug::new(
+            clock.clock(),
             0,
-            Duration::from_millis(400),
-            Duration::from_millis(1000),
-            Duration::from_millis(100),
-            Duration::from_millis(3000),
+            Duration::milliseconds(400),
+            Duration::milliseconds(1000),
+            Duration::milliseconds(100),
+            Duration::milliseconds(3000),
             Some(Arc::new(create_test_signer("test"))),
             DoomslugThresholdMode::TwoThirds,
         );
 
-        let mut now = StaticClock::instant(); // For the test purposes the absolute value of the initial instant doesn't matter
-
         // Set a new tip, must produce an endorsement
-        ds.set_tip(now, hash(&[1]), 1, 1);
-        assert_eq!(ds.process_timer(now + Duration::from_millis(399)).len(), 0);
-        let approval =
-            ds.process_timer(now + Duration::from_millis(400)).into_iter().nth(0).unwrap();
+        ds.set_tip(hash(&[1]), 1, 1);
+        clock.advance(Duration::milliseconds(399));
+        assert_eq!(ds.process_timer().len(), 0);
+        clock.advance(Duration::milliseconds(1));
+        let approval = ds.process_timer().into_iter().nth(0).unwrap();
         assert_eq!(approval.inner, ApprovalInner::Endorsement(hash(&[1])));
         assert_eq!(approval.target_height, 2);
 
         // Same tip => no approval
-        assert_eq!(ds.process_timer(now + Duration::from_millis(400)), vec![]);
+        assert_eq!(ds.process_timer(), vec![]);
 
         // The block was `ds_final` and therefore started the timer. Try checking before one second expires
-        assert_eq!(ds.process_timer(now + Duration::from_millis(999)), vec![]);
+        clock.advance(Duration::milliseconds(599));
+        assert_eq!(ds.process_timer(), vec![]);
 
         // But one second should trigger the skip
-        match ds.process_timer(now + Duration::from_millis(1000)) {
+        clock.advance(Duration::milliseconds(1));
+        match ds.process_timer() {
             approvals if approvals.is_empty() => assert!(false),
             approvals => {
                 assert_eq!(approvals[0].inner, ApprovalInner::Skip(1));
@@ -824,29 +819,32 @@ mod tests {
             }
         }
 
-        // Shift now 1 second forward
-        now += Duration::from_millis(1000);
+        // Shift 1 second forward
+        clock.advance(Duration::seconds(1));
 
         // Not processing a block at height 2 should not produce an appoval
-        ds.set_tip(now, hash(&[2]), 2, 0);
-        assert_eq!(ds.process_timer(now + Duration::from_millis(400)), vec![]);
+        ds.set_tip(hash(&[2]), 2, 0);
+        clock.advance(Duration::milliseconds(400));
+        assert_eq!(ds.process_timer(), vec![]);
 
-        // Shift now 1 second forward
-        now += Duration::from_millis(1000);
+        // Shift 1 second forward
+        clock.advance(Duration::seconds(1));
 
         // But at height 3 should (also neither block has finality set, keep last final at 0 for now)
-        ds.set_tip(now, hash(&[3]), 3, 0);
-        let approval =
-            ds.process_timer(now + Duration::from_millis(400)).into_iter().nth(0).unwrap();
+        ds.set_tip(hash(&[3]), 3, 0);
+        clock.advance(Duration::milliseconds(400));
+        let approval = ds.process_timer().into_iter().nth(0).unwrap();
         assert_eq!(approval.inner, ApprovalInner::Endorsement(hash(&[3])));
         assert_eq!(approval.target_height, 4);
 
         // Move 1 second further
-        now += Duration::from_millis(1000);
+        clock.advance(Duration::seconds(1));
 
-        assert_eq!(ds.process_timer(now + Duration::from_millis(199)), vec![]);
+        clock.advance(Duration::milliseconds(199));
+        assert_eq!(ds.process_timer(), vec![]);
 
-        match ds.process_timer(now + Duration::from_millis(200)) {
+        clock.advance(Duration::milliseconds(1));
+        match ds.process_timer() {
             approvals if approvals.is_empty() => assert!(false),
             approvals if approvals.len() == 1 => {
                 assert_eq!(approvals[0].inner, ApprovalInner::Skip(3));
@@ -856,12 +854,14 @@ mod tests {
         }
 
         // Move 1 second further
-        now += Duration::from_millis(1000);
+        clock.advance(Duration::seconds(1));
 
         // Now skip 5 (the extra delay is 200+300 = 500)
-        assert_eq!(ds.process_timer(now + Duration::from_millis(499)), vec![]);
+        clock.advance(Duration::milliseconds(499));
+        assert_eq!(ds.process_timer(), vec![]);
 
-        match ds.process_timer(now + Duration::from_millis(500)) {
+        clock.advance(Duration::milliseconds(1));
+        match ds.process_timer() {
             approvals if approvals.is_empty() => assert!(false),
             approvals => {
                 assert_eq!(approvals[0].inner, ApprovalInner::Skip(3));
@@ -870,12 +870,14 @@ mod tests {
         }
 
         // Move 1 second further
-        now += Duration::from_millis(1000);
+        clock.advance(Duration::seconds(1));
 
         // Skip 6 (the extra delay is 0+200+300+400 = 900)
-        assert_eq!(ds.process_timer(now + Duration::from_millis(899)), vec![]);
+        clock.advance(Duration::milliseconds(899));
+        assert_eq!(ds.process_timer(), vec![]);
 
-        match ds.process_timer(now + Duration::from_millis(900)) {
+        clock.advance(Duration::milliseconds(1));
+        match ds.process_timer() {
             approvals if approvals.is_empty() => assert!(false),
             approvals => {
                 assert_eq!(approvals[0].inner, ApprovalInner::Skip(3));
@@ -884,29 +886,33 @@ mod tests {
         }
 
         // Move 1 second further
-        now += Duration::from_millis(1000);
+        clock.advance(Duration::seconds(1));
 
         // Accept block at 5 with finality on the prev block, expect it to not produce an approval
-        ds.set_tip(now, hash(&[5]), 5, 4);
-        assert_eq!(ds.process_timer(now + Duration::from_millis(400)), vec![]);
+        ds.set_tip(hash(&[5]), 5, 4);
+        clock.advance(Duration::milliseconds(400));
+        assert_eq!(ds.process_timer(), vec![]);
 
         // Skip a whole bunch of heights by moving 100 seconds ahead
-        now += Duration::from_millis(100_000);
-        assert!(ds.process_timer(now).len() > 10);
+        clock.advance(Duration::seconds(100));
+        assert!(ds.process_timer().len() > 10);
 
         // Add some random small number of milliseconds to test that when the next block is added, the
         // timer is reset
-        now += Duration::from_millis(17);
+        clock.advance(Duration::milliseconds(17));
 
         // No approval, since we skipped 6
-        ds.set_tip(now, hash(&[6]), 6, 4);
-        assert_eq!(ds.process_timer(now + Duration::from_millis(400)), vec![]);
+        ds.set_tip(hash(&[6]), 6, 4);
+        clock.advance(Duration::milliseconds(400 - 17));
+        assert_eq!(ds.process_timer(), vec![]);
 
         // The block height was less than the timer height, and thus the timer was reset.
         // The wait time for height 7 with last ds final block at 5 is 1100
-        assert_eq!(ds.process_timer(now + Duration::from_millis(1099)), vec![]);
+        clock.advance(Duration::milliseconds(699));
+        assert_eq!(ds.process_timer(), vec![]);
 
-        match ds.process_timer(now + Duration::from_millis(1100)) {
+        clock.advance(Duration::milliseconds(1));
+        match ds.process_timer() {
             approvals if approvals.is_empty() => assert!(false),
             approvals => {
                 assert_eq!(approvals[0].inner, ApprovalInner::Skip(6));
@@ -935,17 +941,17 @@ mod tests {
             .collect::<Vec<_>>();
 
         let signer = Arc::new(create_test_signer("test"));
+        let clock = FakeClock::new(Utc::UNIX_EPOCH);
         let mut ds = Doomslug::new(
+            clock.clock(),
             0,
-            Duration::from_millis(400),
-            Duration::from_millis(1000),
-            Duration::from_millis(100),
-            Duration::from_millis(3000),
+            Duration::milliseconds(400),
+            Duration::milliseconds(1000),
+            Duration::milliseconds(100),
+            Duration::milliseconds(3000),
             Some(signer),
             DoomslugThresholdMode::TwoThirds,
         );
-
-        let mut now = StaticClock::instant();
 
         // In the comments below the format is
         // account, height -> approved stake
@@ -954,7 +960,6 @@ mod tests {
         // "test1", 2 -> 2
         assert_eq!(
             ds.on_approval_message_internal(
-                now,
                 &Approval::new(hash(&[1]), 1, 2, &signers[0]),
                 &stakes,
             ),
@@ -964,7 +969,6 @@ mod tests {
         // "test3", 4 -> 3
         assert_eq!(
             ds.on_approval_message_internal(
-                now,
                 &Approval::new(hash(&[1]), 1, 4, &signers[2]),
                 &stakes,
             ),
@@ -974,17 +978,17 @@ mod tests {
         // "test4", 4 -> 4
         assert_eq!(
             ds.on_approval_message_internal(
-                now,
                 &Approval::new(hash(&[1]), 1, 4, &signers[3]),
                 &stakes,
             ),
             DoomslugBlockProductionReadiness::NotReady,
         );
 
+        clock.advance(Duration::milliseconds(100));
+
         // "test1", 4 -> same account, still 5
         assert_eq!(
             ds.on_approval_message_internal(
-                now + Duration::from_millis(100),
                 &Approval::new(hash(&[1]), 1, 4, &signers[3]),
                 &stakes,
             ),
@@ -994,49 +998,44 @@ mod tests {
         // "test2", 4 -> 5
         assert_eq!(
             ds.on_approval_message_internal(
-                now,
                 &Approval::new(hash(&[1]), 1, 4, &signers[1]),
                 &stakes,
             ),
-            DoomslugBlockProductionReadiness::ReadySince(now),
+            DoomslugBlockProductionReadiness::ReadySince(clock.now()),
         );
 
         // "test1", 4 -> 7
         assert_eq!(
             ds.on_approval_message_internal(
-                now,
                 &Approval::new(hash(&[1]), 1, 4, &signers[0]),
                 &stakes,
             ),
-            DoomslugBlockProductionReadiness::ReadySince(now),
+            DoomslugBlockProductionReadiness::ReadySince(clock.now()),
         );
 
         // "test4", 2 -> 3
         assert_eq!(
             ds.on_approval_message_internal(
-                now,
                 &Approval::new(hash(&[1]), 1, 2, &signers[3]),
                 &stakes,
             ),
             DoomslugBlockProductionReadiness::NotReady,
         );
 
-        now += Duration::from_millis(200);
+        clock.advance(Duration::milliseconds(200));
 
         // "test3", 2 -> 6
         assert_eq!(
             ds.on_approval_message_internal(
-                now,
                 &Approval::new(hash(&[1]), 1, 2, &signers[2]),
                 &stakes,
             ),
-            DoomslugBlockProductionReadiness::ReadySince(now),
+            DoomslugBlockProductionReadiness::ReadySince(clock.now()),
         );
 
         // A different parent hash
         assert_eq!(
             ds.on_approval_message_internal(
-                now,
                 &Approval::new(hash(&[2]), 2, 4, &signers[1]),
                 &stakes,
             ),
@@ -1061,7 +1060,8 @@ mod tests {
             })
             .map(|stake| (stake, false))
             .collect::<Vec<_>>();
-        let mut tracker = DoomslugApprovalsTrackersAtHeight::new();
+        let clock = FakeClock::new(Utc::UNIX_EPOCH);
+        let mut tracker = DoomslugApprovalsTrackersAtHeight::new(clock.clock());
 
         let a1_1 = Approval::new(hash(&[1]), 1, 4, &signers[0]);
         let a1_2 = Approval::new(hash(&[1]), 1, 4, &signers[1]);
@@ -1072,12 +1072,7 @@ mod tests {
         let a2_3 = Approval::new(hash(&[3]), 3, 4, &signers[2]);
 
         // Process first approval, and then process it again and make sure it works
-        tracker.process_approval(
-            StaticClock::instant(),
-            &a1_1,
-            &stakes,
-            DoomslugThresholdMode::TwoThirds,
-        );
+        tracker.process_approval(&a1_1, &stakes, DoomslugThresholdMode::TwoThirds);
 
         assert_eq!(
             tracker
@@ -1097,12 +1092,7 @@ mod tests {
             0
         );
 
-        tracker.process_approval(
-            StaticClock::instant(),
-            &a1_1,
-            &stakes,
-            DoomslugThresholdMode::TwoThirds,
-        );
+        tracker.process_approval(&a1_1, &stakes, DoomslugThresholdMode::TwoThirds);
 
         assert_eq!(
             tracker
@@ -1123,18 +1113,8 @@ mod tests {
         );
 
         // Process the remaining two approvals on the first block
-        tracker.process_approval(
-            StaticClock::instant(),
-            &a1_2,
-            &stakes,
-            DoomslugThresholdMode::TwoThirds,
-        );
-        tracker.process_approval(
-            StaticClock::instant(),
-            &a1_3,
-            &stakes,
-            DoomslugThresholdMode::TwoThirds,
-        );
+        tracker.process_approval(&a1_2, &stakes, DoomslugThresholdMode::TwoThirds);
+        tracker.process_approval(&a1_3, &stakes, DoomslugThresholdMode::TwoThirds);
 
         assert_eq!(
             tracker
@@ -1155,12 +1135,7 @@ mod tests {
         );
 
         // Process new approvals one by one, expect the approved and endorsed stake to slowly decrease
-        tracker.process_approval(
-            StaticClock::instant(),
-            &a2_1,
-            &stakes,
-            DoomslugThresholdMode::TwoThirds,
-        );
+        tracker.process_approval(&a2_1, &stakes, DoomslugThresholdMode::TwoThirds);
 
         assert_eq!(
             tracker
@@ -1180,12 +1155,7 @@ mod tests {
             5
         );
 
-        tracker.process_approval(
-            StaticClock::instant(),
-            &a2_2,
-            &stakes,
-            DoomslugThresholdMode::TwoThirds,
-        );
+        tracker.process_approval(&a2_2, &stakes, DoomslugThresholdMode::TwoThirds);
 
         assert_eq!(
             tracker
@@ -1206,12 +1176,7 @@ mod tests {
         );
 
         // As we update the last of the three approvals, the tracker for the first block should be completely removed
-        tracker.process_approval(
-            StaticClock::instant(),
-            &a2_3,
-            &stakes,
-            DoomslugThresholdMode::TwoThirds,
-        );
+        tracker.process_approval(&a2_3, &stakes, DoomslugThresholdMode::TwoThirds);
 
         assert!(tracker.approval_trackers.get(&ApprovalInner::Skip(1)).is_none());
 
@@ -1236,12 +1201,7 @@ mod tests {
             5
         );
 
-        tracker.process_approval(
-            StaticClock::instant(),
-            &a2_3,
-            &stakes,
-            DoomslugThresholdMode::TwoThirds,
-        );
+        tracker.process_approval(&a2_3, &stakes, DoomslugThresholdMode::TwoThirds);
 
         assert_eq!(
             tracker

--- a/chain/chain/src/orphan.rs
+++ b/chain/chain/src/orphan.rs
@@ -1,14 +1,12 @@
-use std::collections::{HashMap, HashSet};
-use std::fmt::{Debug, Formatter};
-use std::time::{Duration, Instant};
-
+use near_async::time::{Duration, Instant};
 use near_chain_primitives::Error;
 use near_primitives::block::Block;
 use near_primitives::hash::CryptoHash;
 use near_primitives::sharding::ShardChunkHeader;
-use near_primitives::static_clock::StaticClock;
 use near_primitives::types::{AccountId, BlockHeight, EpochId};
 use near_primitives::utils::MaybeValidated;
+use std::collections::{HashMap, HashSet};
+use std::fmt::{Debug, Formatter};
 use tracing::{debug, debug_span};
 
 use crate::missing_chunks::BlockLike;
@@ -121,7 +119,7 @@ impl OrphanBlockPool {
 
             let mut removed_hashes: HashSet<CryptoHash> = HashSet::default();
             self.orphans.retain(|_, ref mut x| {
-                let keep = x.added.elapsed() < Duration::from_secs(MAX_ORPHAN_AGE_SECS);
+                let keep = x.added.elapsed() < Duration::seconds(MAX_ORPHAN_AGE_SECS as i64);
                 if !keep {
                     removed_hashes.insert(*x.block.hash());
                 }
@@ -261,13 +259,12 @@ impl Chain {
         &mut self,
         block: MaybeValidated<Block>,
         provenance: Provenance,
-        added: Option<Instant>,
         requested_missing_chunks: bool,
     ) {
         let block_hash = *block.hash();
         if !self.orphans.contains(block.hash()) {
             self.orphans.add(
-                Orphan { block, provenance, added: added.unwrap_or_else(StaticClock::instant) },
+                Orphan { block, provenance, added: self.clock.now() },
                 requested_missing_chunks,
             );
         }
@@ -390,8 +387,7 @@ impl Chain {
             debug!(target: "chain", found_orphans = orphans.len(), "Check orphans");
             for orphan in orphans.into_iter() {
                 let block_hash = orphan.hash();
-                self.blocks_delay_tracker
-                    .mark_block_unorphaned(&block_hash, StaticClock::instant());
+                self.blocks_delay_tracker.mark_block_unorphaned(&block_hash);
                 let res = self.start_process_block_async(
                     me,
                     orphan.block,

--- a/chain/chain/src/resharding.rs
+++ b/chain/chain/src/resharding.rs
@@ -404,7 +404,7 @@ impl Chain {
 
             // sleep between batches in order to throttle resharding and leave
             // some resource for the regular node operation
-            std::thread::sleep(config.get().batch_delay);
+            std::thread::sleep(config.get().batch_delay.unsigned_abs());
         }
 
         state_roots = apply_delayed_receipts(

--- a/chain/chain/src/test_utils.rs
+++ b/chain/chain/src/test_utils.rs
@@ -1,12 +1,6 @@
 mod kv_runtime;
 mod validator_schedule;
 
-use chrono::{DateTime, Utc};
-use near_chain_configs::GenesisConfig;
-use num_rational::Ratio;
-use std::cmp::Ordering;
-use std::sync::Arc;
-
 pub use self::kv_runtime::account_id_to_shard_id;
 pub use self::kv_runtime::KeyValueRuntime;
 pub use self::kv_runtime::MockEpochManager;
@@ -17,6 +11,8 @@ use crate::store::ChainStoreAccess;
 use crate::types::{AcceptedBlock, ChainConfig, ChainGenesis};
 use crate::DoomslugThresholdMode;
 use crate::{BlockProcessingArtifact, Provenance};
+use near_async::time::Utc;
+use near_chain_configs::GenesisConfig;
 use near_chain_primitives::Error;
 use near_epoch_manager::shard_tracker::ShardTracker;
 use near_primitives::block::Block;
@@ -29,6 +25,9 @@ use near_primitives::validator_signer::InMemoryValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_store::test_utils::create_test_store;
 use near_store::DBCol;
+use num_rational::Ratio;
+use std::cmp::Ordering;
+use std::sync::Arc;
 use tracing::debug;
 
 pub fn get_chain() -> Chain {
@@ -188,7 +187,7 @@ pub fn setup_with_validators_and_start_time(
     vs: ValidatorSchedule,
     epoch_length: u64,
     tx_validity_period: NumBlocks,
-    start_time: DateTime<Utc>,
+    start_time: Utc,
 ) -> (Chain, Arc<MockEpochManager>, Arc<KeyValueRuntime>, Vec<Arc<InMemoryValidatorSigner>>) {
     let store = create_test_store();
     let signers =

--- a/chain/chain/src/test_utils/kv_runtime.rs
+++ b/chain/chain/src/test_utils/kv_runtime.rs
@@ -6,6 +6,7 @@ use crate::types::{
 };
 use crate::BlockHeader;
 use borsh::{BorshDeserialize, BorshSerialize};
+use near_async::time::Duration;
 use near_chain_configs::{ProtocolConfig, DEFAULT_GC_NUM_EPOCHS_TO_KEEP};
 use near_chain_primitives::Error;
 use near_crypto::{KeyType, PublicKey, SecretKey, Signature};
@@ -53,7 +54,6 @@ use num_rational::Ratio;
 use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
 
 /// Simple key value runtime for tests.
 ///

--- a/chain/chain/src/tests/doomslug.rs
+++ b/chain/chain/src/tests/doomslug.rs
@@ -1,15 +1,13 @@
-use near_primitives::static_clock::StaticClock;
-use near_primitives::test_utils::create_test_signer;
-use rand::{thread_rng, Rng};
-use std::collections::{HashMap, HashSet};
-use std::sync::Arc;
-use std::time::{Duration, Instant};
-
 use crate::{Doomslug, DoomslugThresholdMode};
+use near_async::time::{Duration, FakeClock, Instant, Utc};
 use near_crypto::{KeyType, SecretKey};
 use near_primitives::block::Approval;
 use near_primitives::hash::{hash, CryptoHash};
+use near_primitives::test_utils::create_test_signer;
 use near_primitives::types::{ApprovalStake, BlockHeight};
+use rand::{thread_rng, Rng};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 fn block_hash(height: BlockHeight, ord: usize) -> CryptoHash {
     hash(([height.to_le_bytes(), ord.to_le_bytes()].concat()).as_ref())
@@ -17,7 +15,7 @@ fn block_hash(height: BlockHeight, ord: usize) -> CryptoHash {
 
 fn get_msg_delivery_time(now: Instant, gst: Instant, delta: Duration) -> Instant {
     std::cmp::max(now, gst)
-        + Duration::from_millis(thread_rng().gen_range(0..delta.as_millis()) as u64)
+        + Duration::milliseconds(thread_rng().gen_range(0..delta.whole_milliseconds() as i64) as i64)
 }
 
 /// Runs a single iteration of a fuzz test given specific time until global stabilization and
@@ -50,14 +48,16 @@ fn one_iter(
         .iter()
         .map(|account_id| Arc::new(create_test_signer(account_id)))
         .collect::<Vec<_>>();
+    let clock = FakeClock::new(Utc::UNIX_EPOCH);
     let mut doomslugs = signers
         .iter()
         .map(|signer| {
             Doomslug::new(
+                clock.clock(),
                 0,
-                Duration::from_millis(200),
-                Duration::from_millis(1000),
-                Duration::from_millis(100),
+                Duration::milliseconds(200),
+                Duration::milliseconds(1000),
+                Duration::milliseconds(100),
                 delta * 20, // some arbitrary number larger than delta * 6
                 Some(signer.clone()),
                 DoomslugThresholdMode::TwoThirds,
@@ -65,10 +65,8 @@ fn one_iter(
         })
         .collect::<Vec<_>>();
 
-    let mut now = StaticClock::instant();
-    let started = now;
-
-    let gst = now + time_to_gst;
+    let started = clock.now();
+    let gst = clock.now() + time_to_gst;
     let mut approval_queue: Vec<(Approval, Instant)> = vec![];
     let mut block_queue: Vec<(BlockHeight, usize, BlockHeight, Instant, CryptoHash)> = vec![];
     let mut largest_produced_height: BlockHeight = 1;
@@ -82,19 +80,19 @@ fn one_iter(
     chain_lengths.insert(block_hash(1, 0), 1);
 
     for ds in doomslugs.iter_mut() {
-        ds.set_tip(now, block_hash(1, 0), 1, 1);
+        ds.set_tip(block_hash(1, 0), 1, 1);
         hash_to_block_info.insert(block_hash(1, 0), (1, 1, block_hash(1, 0)));
     }
 
     let mut is_done = false;
     while !is_done {
-        now = now + Duration::from_millis(25);
+        clock.advance(Duration::milliseconds(25));
         let mut new_approval_queue = vec![];
         let mut new_block_queue = vec![];
 
         // 1. Process approvals
         for approval in approval_queue.into_iter() {
-            if approval.1 > now {
+            if approval.1 > clock.now() {
                 new_approval_queue.push(approval);
             } else {
                 let me = (approval.0.target_height % 8) as usize;
@@ -109,14 +107,14 @@ fn one_iter(
                     continue;
                 }
 
-                doomslugs[me].on_approval_message(now, &approval.0, &stakes);
+                doomslugs[me].on_approval_message(&approval.0, &stakes);
             }
         }
         approval_queue = new_approval_queue;
 
         // 2. Process blocks
         for block in block_queue.into_iter() {
-            if block.3 > now {
+            if block.3 > clock.now() {
                 new_block_queue.push(block);
             } else {
                 let ds = &mut doomslugs[block.1 as usize];
@@ -141,12 +139,7 @@ fn one_iter(
 
                     for block_info in block_infos.into_iter().rev() {
                         if block_info.0 > ds.get_tip().1 {
-                            ds.set_tip(
-                                now,
-                                block_info.2,
-                                block_info.0 as BlockHeight,
-                                block_info.1,
-                            );
+                            ds.set_tip(block_info.2, block_info.0 as BlockHeight, block_info.1);
                         }
                     }
                 }
@@ -156,15 +149,15 @@ fn one_iter(
 
         // 3. Process timers
         for ds in doomslugs.iter_mut() {
-            for approval in ds.process_timer(now) {
-                approval_queue.push((approval, get_msg_delivery_time(now, gst, delta)));
+            for approval in ds.process_timer() {
+                approval_queue.push((approval, get_msg_delivery_time(clock.now(), gst, delta)));
             }
         }
 
         // 4. Produce blocks
         'outer: for (bp_ord, ds) in doomslugs.iter_mut().enumerate() {
             for target_height in (ds.get_tip().1 + 1)..=ds.get_largest_height_crossing_threshold() {
-                if ds.ready_to_produce_block(now, target_height, true, false) {
+                if ds.ready_to_produce_block(target_height, true, false) {
                     let num_blocks_to_produce = if bp_ord < 3 { 2 } else { 1 };
 
                     for block_ord in 0..num_blocks_to_produce {
@@ -206,7 +199,7 @@ fn one_iter(
                                 target_height,
                                 whom,
                                 last_final_height,
-                                get_msg_delivery_time(now, gst, delta),
+                                get_msg_delivery_time(clock.now(), gst, delta),
                                 block_hash,
                             );
                             block_queue.push(block_info);
@@ -238,12 +231,7 @@ fn one_iter(
                         // Accept our own block (only accept the last if are maliciously producing multiple,
                         // so that `ds.get_tip(...)` doesn't return the new block on the next iteration)
                         if block_ord + 1 == num_blocks_to_produce {
-                            ds.set_tip(
-                                now,
-                                block_hash,
-                                target_height as BlockHeight,
-                                last_final_height,
-                            );
+                            ds.set_tip(block_hash, target_height as BlockHeight, last_final_height);
                         }
                     }
                 }
@@ -259,7 +247,8 @@ fn one_iter(
 
                 // Only makes sense for timers that are more than delta in the past, since for more
                 // recent timers the other participant's start time might be in the future
-                if now - ith_timer_start >= delta && now - jth_timer_start >= delta {
+                if clock.now() - ith_timer_start >= delta && clock.now() - jth_timer_start >= delta
+                {
                     if ith_timer_start > jth_timer_start {
                         assert!(ith_timer_start - jth_timer_start <= delta);
                     } else {
@@ -292,7 +281,7 @@ fn one_iter(
         }
     }
 
-    (now - started, largest_produced_height)
+    (clock.now() - started, largest_produced_height)
 }
 
 #[test]
@@ -305,13 +294,13 @@ fn test_fuzzy_doomslug_liveness_and_safety() {
             println!("Staring set of tests. Time to GST: {}, delta: {}", time_to_gst_millis, delta);
             for _iter in 0..10 {
                 let (took, height) = one_iter(
-                    Duration::from_millis(*time_to_gst_millis),
-                    Duration::from_millis(*delta),
+                    Duration::milliseconds(*time_to_gst_millis),
+                    Duration::milliseconds(*delta),
                     *height_goal,
                 );
                 println!(
                     " --> Took {} (simulated) milliseconds and {} heights",
-                    took.as_millis(),
+                    took.whole_milliseconds(),
                     height
                 );
             }

--- a/chain/chain/src/types.rs
+++ b/chain/chain/src/types.rs
@@ -1,28 +1,22 @@
-use std::collections::HashMap;
-use std::time::Duration;
-
 use borsh::{BorshDeserialize, BorshSerialize};
-use chrono::DateTime;
-use chrono::Utc;
+use near_async::time::{Duration, Utc};
 use near_chain_configs::GenesisConfig;
 use near_chain_configs::MutableConfigValue;
-use near_chain_configs::ReshardingConfig;
-use near_pool::types::TransactionGroupIterator;
-use near_primitives::sandbox::state_patch::SandboxStatePatch;
-use near_primitives::sharding::ShardChunkHeader;
-use near_store::flat::FlatStorageManager;
-use near_store::StorageError;
-use num_rational::Rational32;
-
 use near_chain_configs::ProtocolConfig;
+use near_chain_configs::ReshardingConfig;
 use near_chain_primitives::Error;
+pub use near_epoch_manager::EpochManagerAdapter;
+use near_pool::types::TransactionGroupIterator;
+pub use near_primitives::block::{Block, BlockHeader, Tip};
 use near_primitives::challenge::{ChallengesResult, PartialState};
 use near_primitives::checked_feature;
 use near_primitives::errors::InvalidTxError;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{merklize, MerklePath};
 use near_primitives::receipt::Receipt;
+use near_primitives::sandbox::state_patch::SandboxStatePatch;
 use near_primitives::shard_layout::{ShardLayout, ShardUId};
+use near_primitives::sharding::ShardChunkHeader;
 use near_primitives::state_part::PartId;
 use near_primitives::transaction::{ExecutionOutcomeWithId, SignedTransaction};
 use near_primitives::types::validator_stake::{ValidatorStake, ValidatorStakeIter};
@@ -35,10 +29,11 @@ use near_primitives::version::{
     MIN_PROTOCOL_VERSION_NEP_92_FIX,
 };
 use near_primitives::views::{QueryRequest, QueryResponse};
+use near_store::flat::FlatStorageManager;
+use near_store::StorageError;
 use near_store::{PartialStorage, ShardTries, Store, Trie, WrappedTrieChanges};
-
-pub use near_epoch_manager::EpochManagerAdapter;
-pub use near_primitives::block::{Block, BlockHeader, Tip};
+use num_rational::Rational32;
+use std::collections::HashMap;
 
 #[derive(Eq, PartialEq, Debug, Clone)]
 pub enum BlockStatus {
@@ -200,7 +195,7 @@ impl From<&ChainGenesis> for BlockEconomicsConfig {
 /// Chain genesis configuration.
 #[derive(Clone)]
 pub struct ChainGenesis {
-    pub time: DateTime<Utc>,
+    pub time: Utc,
     pub height: BlockHeight,
     pub gas_limit: Gas,
     pub min_gas_price: Balance,
@@ -239,7 +234,7 @@ impl ChainConfig {
 impl ChainGenesis {
     pub fn new(genesis_config: &GenesisConfig) -> Self {
         Self {
-            time: genesis_config.genesis_time,
+            time: Utc::from_unix_timestamp(genesis_config.genesis_time.timestamp()).unwrap(),
             height: genesis_config.genesis_height,
             gas_limit: genesis_config.gas_limit,
             min_gas_price: genesis_config.min_gas_price,
@@ -530,16 +525,14 @@ pub struct LatestKnown {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::Arc;
-
-    use chrono::Utc;
-    use near_primitives::test_utils::{create_test_signer, TestBlockBuilder};
-
+    use near_async::time::Utc;
     use near_primitives::block::{genesis_chunks, Approval};
     use near_primitives::hash::hash;
     use near_primitives::merkle::verify_path;
+    use near_primitives::test_utils::{create_test_signer, TestBlockBuilder};
     use near_primitives::transaction::{ExecutionMetadata, ExecutionOutcome, ExecutionStatus};
     use near_primitives::version::PROTOCOL_VERSION;
+    use std::sync::Arc;
 
     use super::*;
 
@@ -552,7 +545,7 @@ mod tests {
         let genesis = Block::genesis(
             PROTOCOL_VERSION,
             genesis_chunks.into_iter().map(|chunk| chunk.take_header()).collect(),
-            Utc::now(),
+            Utc::now_utc(),
             0,
             100,
             1_000_000_000,

--- a/chain/chain/src/update_shard.rs
+++ b/chain/chain/src/update_shard.rs
@@ -3,6 +3,7 @@ use crate::types::{
     ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, ApplyResultForResharding,
     ReshardingResults, RuntimeAdapter, RuntimeStorageConfig, StorageDataSource,
 };
+use near_async::time::Clock;
 use near_chain_primitives::Error;
 use near_epoch_manager::EpochManagerAdapter;
 use near_primitives::hash::CryptoHash;
@@ -178,7 +179,7 @@ pub fn apply_new_chunk(
     .entered();
     let gas_limit = chunk_header.gas_limit();
 
-    let _timer = CryptoHashTimer::new(chunk_header.chunk_hash().0);
+    let _timer = CryptoHashTimer::new(Clock::real(), chunk_header.chunk_hash().0);
     let storage_config = RuntimeStorageConfig {
         state_root: chunk_header.prev_state_root(),
         use_flat_storage: true,

--- a/chain/chunks/src/shards_manager_actor.rs
+++ b/chain/chunks/src/shards_manager_actor.rs
@@ -1,8 +1,9 @@
-use std::{sync::Arc, time::Duration};
-
+use crate::{
+    adapter::ShardsManagerRequestFromClient, client::ShardsManagerResponse, ShardsManager,
+};
 use actix::{Actor, Addr, Arbiter, ArbiterHandle, Context, Handler};
 use near_async::messaging::Sender;
-use near_async::time;
+use near_async::time::{Clock, Duration};
 use near_chain::{chunks_store::ReadOnlyChunksStore, types::Tip};
 use near_epoch_manager::{shard_tracker::ShardTracker, EpochManagerAdapter};
 use near_network::{
@@ -12,10 +13,7 @@ use near_o11y::WithSpanContext;
 use near_performance_metrics_macros::perf;
 use near_primitives::types::AccountId;
 use near_store::{DBCol, Store, HEADER_HEAD_KEY, HEAD_KEY};
-
-use crate::{
-    adapter::ShardsManagerRequestFromClient, client::ShardsManagerResponse, ShardsManager,
-};
+use std::sync::Arc;
 
 pub struct ShardsManagerActor {
     shards_mgr: ShardsManager,
@@ -32,7 +30,7 @@ impl ShardsManagerActor {
 
         near_performance_metrics::actix::run_later(
             ctx,
-            self.chunk_request_retry_period,
+            self.chunk_request_retry_period.max(Duration::ZERO).unsigned_abs(),
             move |act, ctx| {
                 act.periodically_resend_chunk_requests(ctx);
             },
@@ -96,7 +94,7 @@ pub fn start_shards_manager(
         .expect("ShardsManager must be initialized after the chain is initialized");
     let chunks_store = ReadOnlyChunksStore::new(store);
     let shards_manager = ShardsManager::new(
-        time::Clock::real(),
+        Clock::real(),
         me,
         epoch_manager,
         shard_tracker,

--- a/chain/client-primitives/Cargo.toml
+++ b/chain/client-primitives/Cargo.toml
@@ -18,6 +18,7 @@ serde.workspace = true
 serde_json.workspace = true
 strum.workspace = true
 thiserror.workspace = true
+time.workspace = true
 tracing.workspace = true
 yansi.workspace = true
 

--- a/chain/client-primitives/src/debug.rs
+++ b/chain/client-primitives/src/debug.rs
@@ -1,7 +1,6 @@
 //! Structs in this module are used for debug purposes, and might change at any time
 //! without backwards compatibility of JSON encoding.
 use crate::types::StatusError;
-use chrono::DateTime;
 use near_primitives::types::EpochId;
 use near_primitives::views::{
     CatchupStatusView, ChainProcessingInfo, EpochValidatorInfo, RequestedStatePartsView,
@@ -15,6 +14,7 @@ use near_primitives::{
     views::ValidatorInfo,
 };
 use std::collections::HashMap;
+use time::OffsetDateTime as Utc;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct TrackedShardsView {
@@ -26,7 +26,7 @@ pub struct TrackedShardsView {
 pub struct EpochInfoView {
     pub epoch_id: CryptoHash,
     pub height: BlockHeight,
-    pub first_block: Option<(CryptoHash, DateTime<chrono::Utc>)>,
+    pub first_block: Option<(CryptoHash, Utc)>,
     pub block_producers: Vec<ValidatorInfo>,
     pub chunk_only_producers: Vec<String>,
     pub validator_info: Option<EpochValidatorInfo>,
@@ -83,7 +83,7 @@ pub struct ApprovalHistoryEntry {
     pub parent_height: BlockHeight,
     pub target_height: BlockHeight,
     // Time when we actually created the approval and sent it out.
-    pub approval_creation_time: DateTime<chrono::Utc>,
+    pub approval_creation_time: Utc,
     // The moment when we were ready to send this approval (or skip)
     pub timer_started_ago_millis: u64,
     // But we had to wait at least this long before doing it.
@@ -95,7 +95,7 @@ pub struct ApprovalHistoryEntry {
 #[derive(serde::Serialize, Debug, Default, Clone)]
 pub struct ChunkProduction {
     // Time when we produced the chunk.
-    pub chunk_production_time: Option<DateTime<chrono::Utc>>,
+    pub chunk_production_time: Option<Utc>,
     // How long did the chunk production take (reed solomon encoding, preparing fragments etc.)
     // Doesn't include network latency.
     pub chunk_production_duration_millis: Option<u64>,
@@ -110,7 +110,7 @@ pub struct BlockProduction {
     // set if we didn't produce the block.
     pub chunks_collection_time: Vec<ChunkCollection>,
     // Time when we produced the block, None if we didn't produce the block.
-    pub block_production_time: Option<DateTime<chrono::Utc>>,
+    pub block_production_time: Option<Utc>,
     // Whether this block is included on the canonical chain.
     pub block_included: bool,
 }
@@ -121,7 +121,7 @@ pub struct ChunkCollection {
     pub chunk_producer: AccountId,
     // Time when the chunk was received. Note that this field can be filled even if the block doesn't
     // include a chunk for the shard, if a chunk at this height was received after the block was produced.
-    pub received_time: Option<DateTime<chrono::Utc>>,
+    pub received_time: Option<Utc>,
     // Whether the block included a chunk for this shard
     pub chunk_included: bool,
 }
@@ -142,9 +142,9 @@ pub struct ProductionAtHeight {
 #[derive(serde::Serialize, Debug, Default, Clone)]
 pub struct ApprovalAtHeightStatus {
     // Map from validator id to the type of approval that they sent and timestamp.
-    pub approvals: HashMap<AccountId, (ApprovalInner, DateTime<chrono::Utc>)>,
+    pub approvals: HashMap<AccountId, (ApprovalInner, Utc)>,
     // Time at which we received 2/3 approvals (doomslug threshold).
-    pub ready_at: Option<DateTime<chrono::Utc>>,
+    pub ready_at: Option<Utc>,
 }
 
 #[derive(serde::Serialize, Debug)]

--- a/chain/client-primitives/src/types.rs
+++ b/chain/client-primitives/src/types.rs
@@ -1,6 +1,4 @@
 use actix::Message;
-use chrono::DateTime;
-use chrono::Utc;
 use near_chain_configs::{ClientConfig, ProtocolConfigView};
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::{MerklePath, PartialMerkleTree};
@@ -21,6 +19,7 @@ pub use near_primitives::views::{StatusResponse, StatusSyncInfo};
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use time::OffsetDateTime as Utc;
 use tracing::debug_span;
 use yansi::Color::Magenta;
 use yansi::Style;
@@ -48,8 +47,8 @@ impl From<near_primitives::errors::EpochError> for Error {
 
 #[derive(Debug, serde::Serialize)]
 pub struct DownloadStatus {
-    pub start_time: DateTime<Utc>,
-    pub prev_update_time: DateTime<Utc>,
+    pub start_time: Utc,
+    pub prev_update_time: Utc,
     pub run_me: Arc<AtomicBool>,
     pub error: bool,
     pub done: bool,
@@ -58,7 +57,7 @@ pub struct DownloadStatus {
 }
 
 impl DownloadStatus {
-    pub fn new(now: DateTime<Utc>) -> Self {
+    pub fn new(now: Utc) -> Self {
         Self {
             start_time: now,
             prev_update_time: now,
@@ -169,7 +168,7 @@ pub struct ShardSyncDownload {
 
 impl ShardSyncDownload {
     /// Creates a instance of self which includes initial statuses for shard state header download at the given time.
-    pub fn new_download_state_header(now: DateTime<Utc>) -> Self {
+    pub fn new_download_state_header(now: Utc) -> Self {
         Self {
             downloads: vec![DownloadStatus::new(now)],
             status: ShardSyncStatus::StateDownloadHeader,
@@ -177,7 +176,7 @@ impl ShardSyncDownload {
     }
 
     /// Creates a instance of self which includes initial statuses for shard state parts download at the given time.
-    pub fn new_download_state_parts(now: DateTime<Utc>, num_parts: u64) -> Self {
+    pub fn new_download_state_parts(now: Utc, num_parts: u64) -> Self {
         // Avoid using `vec![x; num_parts]`, because each element needs to have
         // its own independent value of `response`.
         let mut downloads = Vec::with_capacity(num_parts as usize);

--- a/chain/client/src/client.rs
+++ b/chain/client/src/client.rs
@@ -19,6 +19,7 @@ use itertools::Itertools;
 use near_async::futures::FutureSpawner;
 use near_async::messaging::IntoSender;
 use near_async::messaging::{CanSend, Sender};
+use near_async::time::{Clock, Duration, Instant};
 use near_chain::chain::VerifyBlockHashAndSignatureResult;
 use near_chain::chain::{
     ApplyStatePartsRequest, BlockCatchUpRequest, BlockMissingChunks, BlocksCatchUpState,
@@ -72,7 +73,6 @@ use near_primitives::sharding::{
     ChunkHash, EncodedShardChunk, PartialEncodedChunk, ReedSolomonWrapper, ShardChunk,
     ShardChunkHeader, ShardInfo,
 };
-use near_primitives::static_clock::StaticClock;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, ApprovalStake, BlockHeight, EpochId, NumBlocks, ShardId};
@@ -87,17 +87,16 @@ use std::cmp::max;
 use std::collections::{HashMap, HashSet};
 use std::sync::Arc;
 use std::sync::RwLock;
-use std::time::{Duration, Instant};
 use tracing::{debug, debug_span, error, info, trace, warn};
 
 const NUM_REBROADCAST_BLOCKS: usize = 30;
 
 /// The time we wait for the response to a Epoch Sync request before retrying
 // TODO #3488 set 30_000
-pub const EPOCH_SYNC_REQUEST_TIMEOUT: Duration = Duration::from_millis(1_000);
+pub const EPOCH_SYNC_REQUEST_TIMEOUT: Duration = Duration::milliseconds(1_000);
 /// How frequently a Epoch Sync response can be sent to a particular peer
 // TODO #3488 set 60_000
-pub const EPOCH_SYNC_PEER_TIMEOUT: Duration = Duration::from_millis(10);
+pub const EPOCH_SYNC_PEER_TIMEOUT: Duration = Duration::milliseconds(10);
 /// Drop blocks whose height are beyond head + horizon if it is not in the current epoch.
 const BLOCK_HORIZON: u64 = 500;
 
@@ -127,6 +126,7 @@ pub struct Client {
     #[cfg(feature = "sandbox")]
     pub(crate) accrued_fastforward_delta: near_primitives::types::BlockHeightDelta,
 
+    pub clock: Clock,
     pub config: ClientConfig,
     pub sync_status: SyncStatus,
     pub state_sync_adapter: Arc<RwLock<SyncAdapter>>,
@@ -237,6 +237,7 @@ pub struct ProduceChunkResult {
 
 impl Client {
     pub fn new(
+        clock: Clock,
         config: ClientConfig,
         chain_genesis: ChainGenesis,
         epoch_manager: Arc<dyn EpochManagerAdapter>,
@@ -335,11 +336,12 @@ impl Client {
         let parity_parts = epoch_manager.num_total_parts() - data_parts;
 
         let doomslug = Doomslug::new(
+            clock.clone(),
             chain.chain_store().largest_target_height()?,
-            config.min_block_production_delay,
-            config.max_block_production_delay,
-            config.max_block_production_delay / 10,
-            config.max_block_wait_delay,
+            near_async::time::Duration::try_from(config.min_block_production_delay).unwrap(),
+            near_async::time::Duration::try_from(config.max_block_production_delay).unwrap(),
+            near_async::time::Duration::try_from(config.max_block_production_delay / 10).unwrap(),
+            near_async::time::Duration::try_from(config.max_block_wait_delay).unwrap(),
             validator_signer.clone(),
             doomslug_threshold_mode,
         );
@@ -363,6 +365,7 @@ impl Client {
             produce_invalid_tx_in_chunks: false,
             #[cfg(feature = "sandbox")]
             accrued_fastforward_delta: 0,
+            clock: clock.clone(),
             config,
             sync_status,
             state_sync_adapter,
@@ -384,7 +387,7 @@ impl Client {
             challenges: Default::default(),
             rs_for_chunk_production: ReedSolomonWrapper::new(data_parts, parity_parts),
             rebroadcasted_blocks: lru::LruCache::new(NUM_REBROADCAST_BLOCKS),
-            last_time_head_progress_made: StaticClock::instant(),
+            last_time_head_progress_made: clock.now(),
             block_production_info: BlockProductionTracker::new(),
             chunk_production_info: lru::LruCache::new(PRODUCTION_TIMES_CACHE_SIZE),
             tier1_accounts_cache: None,
@@ -400,14 +403,14 @@ impl Client {
     // Checks if it's been at least `stall_timeout` since the last time the head was updated, or
     // this method was called. If yes, rebroadcasts the current head.
     pub fn check_head_progress_stalled(&mut self, stall_timeout: Duration) -> Result<(), Error> {
-        if StaticClock::instant() > self.last_time_head_progress_made + stall_timeout
+        if self.clock.now() > self.last_time_head_progress_made + stall_timeout
             && !self.sync_status.is_syncing()
         {
             let block = self.chain.get_block(&self.chain.head()?.last_block_hash)?;
             self.network_adapter.send(PeerManagerMessageRequest::NetworkRequests(
                 NetworkRequests::Block { block: block },
             ));
-            self.last_time_head_progress_made = StaticClock::instant();
+            self.last_time_head_progress_made = self.clock.now();
         }
         Ok(())
     }
@@ -694,9 +697,9 @@ impl Client {
         };
 
         #[cfg(feature = "sandbox")]
-        let timestamp_override = Some(StaticClock::utc() + self.sandbox_delta_time());
+        let block_timestamp = self.clock.now_utc() + self.sandbox_delta_time();
         #[cfg(not(feature = "sandbox"))]
-        let timestamp_override = None;
+        let block_timestamp = self.clock.now_utc();
 
         // Get block extra from previous block.
         let block_merkle_tree = self.chain.chain_store().get_block_merkle_tree(&prev_hash)?;
@@ -783,7 +786,7 @@ impl Client {
             &*validator_signer,
             next_bp_hash,
             block_merkle_root,
-            timestamp_override,
+            block_timestamp,
         );
 
         // Update latest known even before returning block out, to prevent race conditions.
@@ -897,8 +900,8 @@ impl Client {
         self.chunk_production_info.put(
             (next_height, shard_id),
             ChunkProduction {
-                chunk_production_time: Some(StaticClock::utc()),
-                chunk_production_duration_millis: Some(timer.elapsed().as_millis() as u64),
+                chunk_production_time: Some(self.clock.now_utc()),
+                chunk_production_duration_millis: Some(timer.elapsed().whole_milliseconds() as u64),
             },
         );
         if let Some(limit) = prepared_transactions.limited_by {
@@ -1083,11 +1086,7 @@ impl Client {
     ) -> Result<(), near_chain::Error> {
         let _span =
             debug_span!(target: "chain", "receive_block_impl", was_requested, ?peer_id).entered();
-        self.chain.blocks_delay_tracker.mark_block_received(
-            &block,
-            StaticClock::instant(),
-            StaticClock::utc(),
-        );
+        self.chain.blocks_delay_tracker.mark_block_received(&block);
         // To protect ourselves from spamming, we do some pre-check on block height before we do any
         // real processing.
         if !self.check_block_height(&block, was_requested)? {
@@ -1387,7 +1386,7 @@ impl Client {
         apply_chunks_done_callback: DoneApplyChunkCallback,
     ) {
         let chunk_header = partial_chunk.cloned_header();
-        self.chain.blocks_delay_tracker.mark_chunk_completed(&chunk_header, StaticClock::utc());
+        self.chain.blocks_delay_tracker.mark_chunk_completed(&chunk_header);
         self.block_production_info
             .record_chunk_collected(partial_chunk.height_created(), partial_chunk.shard_id());
 
@@ -1439,12 +1438,7 @@ impl Client {
             } else {
                 self.chain.get_block_header(&last_final_hash)?.height()
             };
-            self.doomslug.set_tip(
-                StaticClock::instant(),
-                tip.last_block_hash,
-                tip.height,
-                last_final_height,
-            );
+            self.doomslug.set_tip(tip.last_block_hash, tip.height, last_final_height);
         }
 
         Ok(())
@@ -1461,33 +1455,28 @@ impl Client {
         } else {
             self.chain.get_block_header(&last_final_hash)?.height()
         };
-        self.doomslug.set_tip(
-            StaticClock::instant(),
-            tip.last_block_hash,
-            height,
-            last_final_height,
-        );
+        self.doomslug.set_tip(tip.last_block_hash, height, last_final_height);
 
         Ok(())
     }
 
     /// Gets the advanced timestamp delta in nanoseconds for sandbox once it has been fast-forwarded
     #[cfg(feature = "sandbox")]
-    pub fn sandbox_delta_time(&self) -> chrono::Duration {
-        let avg_block_prod_time = (self.config.min_block_production_delay.as_nanos()
-            + self.config.max_block_production_delay.as_nanos())
+    pub fn sandbox_delta_time(&self) -> Duration {
+        let avg_block_prod_time = (self.config.min_block_production_delay.whole_nanoseconds()
+            + self.config.max_block_production_delay.whole_nanoseconds())
             / 2;
 
-        let ns = (self.accrued_fastforward_delta as u128 * avg_block_prod_time)
+        let ns = (self.accrued_fastforward_delta as i128 * avg_block_prod_time)
             .try_into()
             .unwrap_or_else(|_| {
                 panic!(
-                    "Too high of a delta_height {} to convert into u64",
+                    "Too high of a delta_height {} to convert into i64",
                     self.accrued_fastforward_delta
                 )
             });
 
-        chrono::Duration::nanoseconds(ns)
+        Duration::nanoseconds(ns)
     }
 
     pub fn send_approval(
@@ -1850,10 +1839,9 @@ impl Client {
         blocks_missing_chunks: Vec<BlockMissingChunks>,
         orphans_missing_chunks: Vec<OrphanMissingChunks>,
     ) {
-        let now = StaticClock::utc();
         for BlockMissingChunks { prev_hash, missing_chunks } in blocks_missing_chunks {
             for chunk in &missing_chunks {
-                self.chain.blocks_delay_tracker.mark_chunk_requested(chunk, now);
+                self.chain.blocks_delay_tracker.mark_chunk_requested(chunk);
             }
             self.shards_manager_adapter.send(ShardsManagerRequestFromClient::RequestChunks {
                 chunks_to_request: missing_chunks,
@@ -1865,7 +1853,7 @@ impl Client {
             orphans_missing_chunks
         {
             for chunk in &missing_chunks {
-                self.chain.blocks_delay_tracker.mark_chunk_requested(chunk, now);
+                self.chain.blocks_delay_tracker.mark_chunk_requested(chunk);
             }
             self.shards_manager_adapter.send(
                 ShardsManagerRequestFromClient::RequestChunksForOrphan {
@@ -2074,7 +2062,7 @@ impl Client {
                     return;
                 }
             };
-        self.doomslug.on_approval_message(StaticClock::instant(), approval, &block_producer_stakes);
+        self.doomslug.on_approval_message(approval, &block_producer_stakes);
     }
 
     /// Forwards given transaction to upcoming validators.

--- a/chain/client/src/client_actions.rs
+++ b/chain/client/src/client_actions.rs
@@ -17,6 +17,7 @@ use crate::{metrics, StatusResponse};
 use near_async::futures::{DelayedActionRunner, DelayedActionRunnerExt, FutureSpawner};
 use near_async::messaging::{CanSend, Sender};
 use near_async::time::{Clock, Utc};
+use near_async::time::{Duration, Instant};
 use near_async::{MultiSend, MultiSendMessage, MultiSenderFrom};
 use near_chain::chain::{
     ApplyStatePartsRequest, ApplyStatePartsResponse, BlockCatchUpRequest, BlockCatchUpResponse,
@@ -54,10 +55,9 @@ use near_primitives::block_header::ApprovalType;
 use near_primitives::epoch_manager::RngSeed;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::{AnnounceAccount, PeerId};
-use near_primitives::static_clock::StaticClock;
 use near_primitives::types::BlockHeight;
 use near_primitives::unwrap_or_return;
-use near_primitives::utils::{from_timestamp, MaybeValidated};
+use near_primitives::utils::MaybeValidated;
 use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{DetailedDebugStatus, ValidatorInfo};
@@ -70,12 +70,11 @@ use rand::{thread_rng, Rng};
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 use tokio::sync::broadcast;
 use tracing::{debug, debug_span, error, info, trace, warn};
 
 /// Multiplier on `max_block_time` to wait until deciding that chain stalled.
-const STATUS_WAIT_TIME_MULTIPLIER: u64 = 10;
+const STATUS_WAIT_TIME_MULTIPLIER: i64 = 10;
 /// `max_block_production_time` times this multiplier is how long we wait before rebroadcasting
 /// the current `head`
 const HEAD_STALL_MULTIPLIER: u32 = 4;
@@ -517,8 +516,8 @@ impl ClientActionHandler<Status> for ClientActions {
             if now > block_timestamp {
                 let elapsed = (now - block_timestamp).unsigned_abs();
                 if elapsed
-                    > Duration::from_millis(
-                        self.client.config.max_block_production_delay.as_millis() as u64
+                    > Duration::milliseconds(
+                        self.client.config.max_block_production_delay.whole_milliseconds() as i64
                             * STATUS_WAIT_TIME_MULTIPLIER,
                     )
                 {
@@ -591,12 +590,12 @@ impl ClientActionHandler<Status> for ClientActions {
                     .client
                     .config
                     .min_block_production_delay
-                    .as_millis() as u64,
+                    .whole_milliseconds() as u64,
             })
         } else {
             None
         };
-        let uptime_sec = StaticClock::utc().timestamp() - self.info_helper.boot_time_seconds;
+        let uptime_sec = self.clock.now_utc().unix_timestamp() - self.info_helper.boot_time_seconds;
         Ok(StatusResponse {
             version: self.client.config.version.clone(),
             protocol_version,
@@ -608,7 +607,7 @@ impl ClientActionHandler<Status> for ClientActions {
                 latest_block_hash: head.last_block_hash,
                 latest_block_height: head.height,
                 latest_state_root,
-                latest_block_time: from_timestamp(latest_block_time),
+                latest_block_time: Utc::from_unix_timestamp(latest_block_time as i64).unwrap(),
                 syncing: self.client.sync_status.is_syncing(),
                 earliest_block_hash,
                 earliest_block_height,
@@ -773,7 +772,7 @@ impl ClientActions {
             Some(signer) => signer,
         };
 
-        let now = StaticClock::instant();
+        let now = self.clock.now();
         // Check that we haven't announced it too recently
         if let Some(last_validator_announce_time) = self.last_validator_announce_time {
             // Don't make announcement if have passed less than half of the time in which other peers
@@ -859,7 +858,8 @@ impl ClientActions {
         let delta_time = self.client.sandbox_delta_time();
         let new_latest_known = near_chain::types::LatestKnown {
             height: block_height + delta_height,
-            seen: near_primitives::utils::to_timestamp(StaticClock::utc() + delta_time),
+            seen: self.clock.now_utc().checked_add(delta_time).unwrap().unix_timestamp_nanos()
+                as u64,
         };
 
         Ok(Some(new_latest_known))
@@ -970,7 +970,6 @@ impl ClientActions {
                     || num_chunks == self.client.epoch_manager.shard_ids(&epoch_id).unwrap().len();
 
                 if self.client.doomslug.ready_to_produce_block(
-                    StaticClock::instant(),
                     height,
                     have_all_chunks,
                     log_block_production_info,
@@ -1054,6 +1053,7 @@ impl ClientActions {
             );
             delay = core::cmp::min(delay, self.doomslug_timer_next_attempt - now)
         }
+        tracing::info!(block_production_started = self.block_production_started);
         if self.block_production_started {
             self.block_production_next_attempt = self.run_timer(
                 self.client.config.block_production_tracking_delay,
@@ -1079,7 +1079,7 @@ impl ClientActions {
         );
         delay = core::cmp::min(delay, self.log_summary_timer_next_attempt - now);
         timer.observe_duration();
-        core::cmp::max(delay, near_async::time::Duration::ZERO).unsigned_abs()
+        delay
     }
 
     /// "Unfinished" blocks means that blocks that client has started the processing and haven't
@@ -1110,9 +1110,11 @@ impl ClientActions {
     }
 
     fn try_doomslug_timer(&mut self) {
-        let _span = tracing::debug_span!(target: "client", "try_doomslug_timer").entered();
+        let _span =
+            tracing::debug_span!(target: "client", "try_doomslug_timer", time=?self.clock.now_utc())
+                .entered();
         let _ = self.client.check_and_update_doomslug_tip();
-        let approvals = self.client.doomslug.process_timer(StaticClock::instant());
+        let approvals = self.client.doomslug.process_timer();
 
         // Important to save the largest approval target height before sending approvals, so
         // that if the node crashes in the meantime, we cannot get slashed on recovery
@@ -1735,7 +1737,7 @@ impl ClientActions {
                 }
             } else if block_hash == sync_hash {
                 // The first block of the new epoch.
-                self.client.chain.save_orphan(block, Provenance::NONE, None, false);
+                self.client.chain.save_orphan(block, Provenance::NONE, false);
             }
         }
         true

--- a/chain/client/src/client_actor.rs
+++ b/chain/client/src/client_actor.rs
@@ -7,11 +7,11 @@
 
 use actix::{Actor, Addr, AsyncContext, Context, Handler};
 use actix_rt::{Arbiter, ArbiterHandle};
-use chrono::{DateTime, Utc};
 use near_async::actix::AddrWithAutoSpanContextExt;
 use near_async::futures::ActixArbiterHandleFutureSpawner;
 use near_async::messaging::{IntoMultiSender, IntoSender, Sender};
-use near_async::time::Clock;
+use near_async::time::Utc;
+use near_async::time::{Clock, Duration};
 use near_chain::state_snapshot_actor::SnapshotCallbacks;
 use near_chain::types::RuntimeAdapter;
 use near_chain::ChainGenesis;
@@ -161,23 +161,18 @@ pub fn random_seed_from_thread() -> RngSeed {
 }
 
 /// Blocks the program until given genesis time arrives.
-fn wait_until_genesis(genesis_time: &DateTime<Utc>) {
+fn wait_until_genesis(genesis_time: &Utc) {
     loop {
-        // Get chrono::Duration::num_seconds() by deducting genesis_time from now.
-        let duration = genesis_time.signed_duration_since(StaticClock::utc());
-        let chrono_seconds = duration.num_seconds();
-        // Check if number of seconds in chrono::Duration larger than zero.
-        if chrono_seconds <= 0 {
+        let duration = *genesis_time - StaticClock::utc();
+        if duration <= Duration::ZERO {
             break;
         }
-        tracing::info!(target: "near", "Waiting until genesis: {}d {}h {}m {}s", duration.num_days(),
-              (duration.num_hours() % 24),
-              (duration.num_minutes() % 60),
-              (duration.num_seconds() % 60));
-        let wait = std::cmp::min(
-            std::time::Duration::from_secs(10),
-            std::time::Duration::from_secs(chrono_seconds as u64),
-        );
+        tracing::info!(target: "near", "Waiting until genesis: {}d {}h {}m {}s",
+              duration.whole_days(),
+              (duration.whole_hours() % 24),
+              (duration.whole_minutes() % 60),
+              (duration.whole_seconds() % 60));
+        let wait = duration.min(Duration::seconds(10)).unsigned_abs();
         std::thread::sleep(wait);
     }
 }
@@ -206,6 +201,7 @@ pub fn start_client(
 
     wait_until_genesis(&chain_genesis.time);
     let client = Client::new(
+        clock.clone(),
         client_config.clone(),
         chain_genesis,
         epoch_manager,

--- a/chain/client/src/debug.rs
+++ b/chain/client/src/debug.rs
@@ -3,7 +3,6 @@
 use crate::chunk_inclusion_tracker::ChunkInclusionTracker;
 use crate::ClientActor;
 use actix::{Context, Handler};
-
 use near_chain::crypto_hash_timer::CryptoHashTimer;
 use near_chain::{near_chain_primitives, Chain, ChainStoreAccess};
 use near_client_primitives::debug::{
@@ -470,7 +469,7 @@ impl ClientActor {
                             processing_time_ms: CryptoHashTimer::get_timer_value(
                                 chunk.chunk_hash().0,
                             )
-                            .map(|s| s.as_millis() as u64),
+                            .map(|s| s.whole_milliseconds() as u64),
                         })
                         .collect(),
                     None => vec![],
@@ -487,7 +486,7 @@ impl ClientActor {
                         is_on_canonical_chain,
                         chunks,
                         processing_time_ms: CryptoHashTimer::get_timer_value(block_hash)
-                            .map(|s| s.as_millis() as u64),
+                            .map(|s| s.whole_milliseconds() as u64),
                         block_timestamp: block_header.raw_timestamp(),
                         gas_price_ratio: block_header.next_gas_price() as f64
                             / initial_gas_price as f64,
@@ -705,11 +704,7 @@ pub(crate) fn new_network_info_view(chain: &Chain, network_info: &NetworkInfo) -
                     })
                     .collect(),
                 account_key: d.account_key.clone(),
-                timestamp: chrono::DateTime::from_naive_utc_and_offset(
-                    chrono::NaiveDateTime::from_timestamp_opt(d.timestamp.unix_timestamp(), 0)
-                        .unwrap(),
-                    chrono::Utc,
-                ),
+                timestamp: d.timestamp,
             })
             .collect(),
         tier1_connections: network_info

--- a/chain/client/src/sync/block.rs
+++ b/chain/client/src/sync/block.rs
@@ -1,5 +1,5 @@
-use chrono::{DateTime, Duration, Utc};
 use near_async::messaging::CanSend;
+use near_async::time::{Duration, Utc};
 use near_chain::Chain;
 use near_chain::{check_known, ChainStoreAccess};
 use near_client_primitives::types::SyncStatus;
@@ -24,7 +24,7 @@ pub struct BlockSyncRequest {
     // Head of the chain at the time of the last requests.
     head: CryptoHash,
     // When the last requests were made.
-    when: DateTime<Utc>,
+    when: Utc,
 }
 
 /// Helper to track block syncing.

--- a/chain/client/src/sync/epoch.rs
+++ b/chain/client/src/sync/epoch.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Duration, Utc};
+use near_async::time::{Duration, Utc};
 use near_network::types::PeerManagerAdapter;
 use near_primitives::hash::CryptoHash;
 use near_primitives::network::PeerId;
@@ -6,7 +6,6 @@ use near_primitives::static_clock::StaticClock;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::EpochId;
 use std::collections::{HashMap, HashSet};
-use std::time::Duration as TimeDuration;
 
 /// Helper to keep track of the Epoch Sync
 // TODO #3488
@@ -16,7 +15,7 @@ pub struct EpochSync {
     /// Datastructure to keep track of when the last request to each peer was made.
     /// Peers do not respond to Epoch Sync requests more frequently than once per a certain time
     /// interval, thus there's no point in requesting more frequently.
-    peer_to_last_request_time: HashMap<PeerId, DateTime<Utc>>,
+    peer_to_last_request_time: HashMap<PeerId, Utc>,
     /// Tracks all the peers who have reported that we are already up to date
     peers_reporting_up_to_date: HashSet<PeerId>,
     /// The last epoch we are synced to
@@ -28,7 +27,7 @@ pub struct EpochSync {
     /// The last epoch id that we have requested
     requested_epoch_id: EpochId,
     /// When and to whom was the last request made
-    last_request_time: DateTime<Utc>,
+    last_request_time: Utc,
     last_request_peer_id: Option<PeerId>,
 
     /// How long to wait for a response before re-requesting the same light client block view
@@ -56,8 +55,8 @@ impl EpochSync {
         genesis_epoch_id: EpochId,
         genesis_next_epoch_id: EpochId,
         first_epoch_block_producers: Vec<ValidatorStake>,
-        request_timeout: TimeDuration,
-        peer_timeout: TimeDuration,
+        request_timeout: Duration,
+        peer_timeout: Duration,
     ) -> Self {
         Self {
             network_adapter,
@@ -69,8 +68,8 @@ impl EpochSync {
             requested_epoch_id: genesis_epoch_id,
             last_request_time: StaticClock::utc(),
             last_request_peer_id: None,
-            request_timeout: Duration::from_std(request_timeout).unwrap(),
-            peer_timeout: Duration::from_std(peer_timeout).unwrap(),
+            request_timeout,
+            peer_timeout,
             received_epoch: false,
             have_all_epochs: false,
             done: false,

--- a/chain/client/src/sync/header.rs
+++ b/chain/client/src/sync/header.rs
@@ -1,5 +1,5 @@
-use chrono::{DateTime, Duration, Utc};
 use near_async::messaging::CanSend;
+use near_async::time::{Duration, Utc};
 use near_chain::{Chain, ChainStoreAccess};
 use near_client_primitives::types::SyncStatus;
 use near_network::types::PeerManagerMessageRequest;
@@ -11,7 +11,6 @@ use near_primitives::types::BlockHeight;
 use rand::seq::SliceRandom;
 use rand::thread_rng;
 use std::cmp::min;
-use std::time::Duration as TimeDuration;
 use tracing::{debug, warn};
 
 /// Maximum number of block headers send over the network.
@@ -25,7 +24,7 @@ pub const NS_PER_SECOND: u128 = 1_000_000_000;
 /// Progress of downloading the currently requested batch of headers.
 struct BatchProgress {
     /// An intermediate timeout by which a certain number of headers is expected.
-    timeout: DateTime<Utc>,
+    timeout: Utc,
     /// Height expected at the moment of `timeout`.
     expected_height: BlockHeight,
     /// Header head height at the moment this batch was requested.
@@ -46,7 +45,7 @@ pub struct HeaderSync {
     syncing_peer: Option<HighestHeightPeerInfo>,
 
     /// When the stalling was first detected.
-    stalling_ts: Option<DateTime<Utc>>,
+    stalling_ts: Option<Utc>,
 
     /// How much time to wait after initial header sync.
     initial_timeout: Duration,
@@ -64,9 +63,9 @@ pub struct HeaderSync {
 impl HeaderSync {
     pub fn new(
         network_adapter: PeerManagerAdapter,
-        initial_timeout: TimeDuration,
-        progress_timeout: TimeDuration,
-        stall_ban_timeout: TimeDuration,
+        initial_timeout: Duration,
+        progress_timeout: Duration,
+        stall_ban_timeout: Duration,
         expected_height_per_second: u64,
     ) -> Self {
         HeaderSync {
@@ -79,9 +78,9 @@ impl HeaderSync {
             },
             syncing_peer: None,
             stalling_ts: None,
-            initial_timeout: Duration::from_std(initial_timeout).unwrap(),
-            progress_timeout: Duration::from_std(progress_timeout).unwrap(),
-            stall_ban_timeout: Duration::from_std(stall_ban_timeout).unwrap(),
+            initial_timeout: initial_timeout,
+            progress_timeout: progress_timeout,
+            stall_ban_timeout: stall_ban_timeout,
             expected_height_per_second,
         }
     }
@@ -159,8 +158,7 @@ impl HeaderSync {
         time_delta: Duration,
     ) -> BlockHeight {
         (old_height as u128
-            + (time_delta.num_nanoseconds().unwrap() as u128
-                * self.expected_height_per_second as u128
+            + (time_delta.whole_nanoseconds() as u128 * self.expected_height_per_second as u128
                 / NS_PER_SECOND)) as u64
     }
 
@@ -293,8 +291,8 @@ impl HeaderSync {
         &self,
         current_height: BlockHeight,
         expected_height: BlockHeight,
-        now: DateTime<Utc>,
-        timeout: DateTime<Utc>,
+        now: Utc,
+        timeout: Utc,
     ) -> bool {
         if now <= timeout {
             self.compute_expected_height(current_height, timeout - now) >= expected_height
@@ -372,26 +370,32 @@ fn get_locator_ordinals(lowest_ordinal: u64, highest_ordinal: u64) -> Vec<u64> {
 
 #[cfg(test)]
 mod test {
-    use std::sync::Arc;
-    use std::thread;
-
     use near_async::messaging::IntoMultiSender;
+    use near_async::time::Duration;
     use near_chain::test_utils::{
         process_block_sync, setup, setup_with_validators_and_start_time, ValidatorSchedule,
     };
+    use near_chain::types::Tip;
     use near_chain::{BlockProcessingArtifact, Provenance};
+    use near_client_primitives::types::SyncStatus;
     use near_crypto::{KeyType, PublicKey};
     use near_network::test_utils::MockPeerManagerAdapter;
+    use near_network::types::{
+        BlockInfo, FullPeerInfo, HighestHeightPeerInfo, NetworkRequests, PeerInfo,
+    };
     use near_primitives::block::{Approval, Block, GenesisId};
-    use near_primitives::network::PeerId;
-    use near_primitives::test_utils::TestBlockBuilder;
-
-    use super::*;
-    use near_network::types::{BlockInfo, FullPeerInfo, PeerInfo};
+    use near_primitives::hash::CryptoHash;
     use near_primitives::merkle::PartialMerkleTree;
+    use near_primitives::network::PeerId;
+    use near_primitives::static_clock::StaticClock;
+    use near_primitives::test_utils::TestBlockBuilder;
     use near_primitives::types::EpochId;
     use near_primitives::version::PROTOCOL_VERSION;
     use num_rational::Ratio;
+    use std::sync::Arc;
+    use std::thread;
+
+    use crate::sync::header::{get_locator_ordinals, HeaderSync, MAX_BLOCK_HEADERS};
 
     #[test]
     fn test_get_locator_ordinals() {
@@ -438,9 +442,9 @@ mod test {
         let mock_adapter = Arc::new(MockPeerManagerAdapter::default());
         let mut header_sync = HeaderSync::new(
             mock_adapter.as_multi_sender(),
-            TimeDuration::from_secs(10),
-            TimeDuration::from_secs(2),
-            TimeDuration::from_secs(120),
+            Duration::seconds(10),
+            Duration::seconds(2),
+            Duration::seconds(120),
             1_000_000_000,
         );
         let (mut chain, _, _, signer) = setup();
@@ -524,9 +528,9 @@ mod test {
         let mock_adapter = Arc::new(MockPeerManagerAdapter::default());
         let mut header_sync = HeaderSync::new(
             mock_adapter.as_multi_sender(),
-            TimeDuration::from_secs(10),
-            TimeDuration::from_secs(2),
-            TimeDuration::from_secs(120),
+            Duration::seconds(10),
+            Duration::seconds(2),
+            Duration::seconds(120),
             1_000_000_000,
         );
         let (mut chain, _, _, signer) = setup();
@@ -634,9 +638,9 @@ mod test {
         // Setup header_sync with expectation of 25 headers/second
         let mut header_sync = HeaderSync::new(
             network_adapter.as_multi_sender(),
-            TimeDuration::from_secs(1),
-            TimeDuration::from_secs(1),
-            TimeDuration::from_secs(3),
+            Duration::seconds(1),
+            Duration::seconds(1),
+            Duration::seconds(3),
             25,
         );
 
@@ -689,7 +693,7 @@ mod test {
 
             last_added_block_ord += 3;
 
-            thread::sleep(TimeDuration::from_millis(500));
+            thread::sleep(std::time::Duration::from_millis(500));
         }
         // 6 blocks / second is fast enough, we should not have banned the peer
         assert!(network_adapter.requests.read().unwrap().is_empty());
@@ -711,7 +715,7 @@ mod test {
 
             last_added_block_ord += 2;
 
-            thread::sleep(TimeDuration::from_millis(500));
+            thread::sleep(std::time::Duration::from_millis(500));
         }
         // This time the peer should be banned, because 4 blocks/s is not fast enough
         let ban_peer = network_adapter.requests.write().unwrap().pop_back().unwrap();
@@ -728,9 +732,9 @@ mod test {
         let mock_adapter = Arc::new(MockPeerManagerAdapter::default());
         let mut header_sync = HeaderSync::new(
             mock_adapter.as_multi_sender(),
-            TimeDuration::from_secs(10),
-            TimeDuration::from_secs(2),
-            TimeDuration::from_secs(120),
+            Duration::seconds(10),
+            Duration::seconds(2),
+            Duration::seconds(120),
             1_000_000_000,
         );
 
@@ -791,7 +795,7 @@ mod test {
                 &*signers2[0],
                 *last_block.header().next_bp_hash(),
                 block_merkle_tree.root(),
-                None,
+                StaticClock::utc(),
             );
             block_merkle_tree.insert(*block.hash());
             chain2.process_block_header(block.header(), &mut Vec::new()).unwrap(); // just to validate

--- a/chain/client/src/sync_jobs_actions.rs
+++ b/chain/client/src/sync_jobs_actions.rs
@@ -1,5 +1,6 @@
 use near_async::futures::{FutureSpawner, FutureSpawnerExt};
 use near_async::messaging::{CanSend, Sender};
+use near_async::time::Duration;
 use near_async::{MultiSend, MultiSendMessage, MultiSenderFrom};
 use near_chain::chain::{
     do_apply_chunks, ApplyStatePartsRequest, ApplyStatePartsResponse, BlockCatchUpRequest,
@@ -11,7 +12,6 @@ use near_primitives::state_part::PartId;
 use near_primitives::state_sync::StatePartKey;
 use near_primitives::types::ShardId;
 use near_store::DBCol;
-use std::time::Duration;
 
 #[derive(Clone, MultiSend, MultiSenderFrom, MultiSendMessage)]
 #[multi_send_message_derive(Debug)]
@@ -134,7 +134,7 @@ impl SyncJobsActions {
             future_spawner.spawn("resharding initial delay", {
                 let sender = self.sync_jobs_sender.clone();
                 async move {
-                    tokio::time::sleep(initial_delay).await;
+                    tokio::time::sleep(initial_delay.max(Duration::ZERO).unsigned_abs()).await;
                     sender.send(resharding_request);
                 }
             });
@@ -150,7 +150,7 @@ impl SyncJobsActions {
             future_spawner.spawn("resharding retry", {
                 let sender = self.sync_jobs_sender.clone();
                 async move {
-                    tokio::time::sleep(retry_delay).await;
+                    tokio::time::sleep(retry_delay.max(Duration::ZERO).unsigned_abs()).await;
                     sender.send(resharding_request);
                 }
             });

--- a/chain/client/src/test_utils/block_stats.rs
+++ b/chain/client/src/test_utils/block_stats.rs
@@ -1,10 +1,9 @@
-use std::cmp::max;
-use std::collections::HashMap;
-use std::time::{Duration, Instant};
-
+use near_async::time::{Duration, Instant};
 use near_primitives::block::Block;
 use near_primitives::hash::CryptoHash;
 use near_primitives::static_clock::StaticClock;
+use std::cmp::max;
+use std::collections::HashMap;
 use tracing::info;
 
 pub struct BlockStats {
@@ -73,8 +72,8 @@ impl BlockStats {
 
     pub fn check_stats(&mut self, force: bool) {
         let now = StaticClock::instant();
-        let diff = now.duration_since(self.last_check);
-        if !force && diff.lt(&Duration::from_secs(60)) {
+        let diff = now - self.last_check;
+        if !force && diff < Duration::seconds(60) {
             return;
         }
         self.last_check = now;

--- a/chain/client/src/test_utils/client.rs
+++ b/chain/client/src/test_utils/client.rs
@@ -250,7 +250,7 @@ pub fn create_chunk(
         &*client.validator_signer.as_ref().unwrap().clone(),
         *last_block.header().next_bp_hash(),
         block_merkle_tree.root(),
-        None,
+        client.clock.now_utc(),
     );
     (
         ProduceChunkResult {

--- a/chain/client/src/test_utils/client_actions_test_utils.rs
+++ b/chain/client/src/test_utils/client_actions_test_utils.rs
@@ -1,6 +1,7 @@
 use crate::client_actions::{ClientActionHandler, ClientActions, ClientSenderForClientMessage};
 use crate::sync_jobs_actions::ClientSenderForSyncJobsMessage;
 use near_async::test_loop::event_handler::LoopEventHandler;
+use near_chunks::client::ShardsManagerResponse;
 
 pub fn forward_client_messages_from_client_to_client_actions(
 ) -> LoopEventHandler<ClientActions, ClientSenderForClientMessage> {
@@ -17,5 +18,12 @@ pub fn forward_client_messages_from_sync_jobs_to_client_actions(
         }
         ClientSenderForSyncJobsMessage::_block_catch_up_response(msg) => client_actions.handle(msg),
         ClientSenderForSyncJobsMessage::_resharding_response(msg) => client_actions.handle(msg),
+    })
+}
+
+pub fn forward_client_messages_from_shards_manager(
+) -> LoopEventHandler<ClientActions, ShardsManagerResponse> {
+    LoopEventHandler::new_simple(|msg, client_actions: &mut ClientActions| {
+        client_actions.handle(msg);
     })
 }

--- a/chain/client/src/test_utils/test_env.rs
+++ b/chain/client/src/test_utils/test_env.rs
@@ -1,13 +1,10 @@
-use std::collections::{HashMap, HashSet};
-use std::sync::{Arc, Mutex};
-use std::time::{Duration, Instant};
-
 use crate::stateless_validation::processing_tracker::{
     ProcessingDoneTracker, ProcessingDoneWaiter,
 };
 use crate::Client;
 use near_async::messaging::{CanSend, IntoMultiSender};
 use near_async::time::Clock;
+use near_async::time::{Duration, Instant};
 use near_chain::test_utils::ValidatorSchedule;
 use near_chain::types::Tip;
 use near_chain::{ChainGenesis, Provenance};
@@ -43,13 +40,15 @@ use near_primitives::views::{
 };
 use near_store::ShardUId;
 use once_cell::sync::OnceCell;
+use std::collections::{HashMap, HashSet};
+use std::sync::{Arc, Mutex};
 
 use super::setup::setup_client_with_runtime;
 use super::test_env_builder::TestEnvBuilder;
 use super::TEST_SEED;
 
 /// Timeout used in tests that wait for a specific chunk endorsement to appear
-const CHUNK_ENDORSEMENTS_TIMEOUT: Duration = Duration::from_secs(10);
+const CHUNK_ENDORSEMENTS_TIMEOUT: Duration = Duration::seconds(10);
 
 /// An environment for writing integration tests with multiple clients.
 /// This environment can simulate near nodes without network and it can be configured to use different runtimes.
@@ -419,7 +418,7 @@ impl TestEnv {
                 return Err(TimeoutError(elapsed_since_start));
             }
 
-            std::thread::sleep(Duration::from_millis(50));
+            std::thread::sleep(std::time::Duration::from_millis(50));
         }
     }
 

--- a/chain/client/src/tests/query_client.rs
+++ b/chain/client/src/tests/query_client.rs
@@ -1,17 +1,14 @@
-use actix::System;
-use futures::{future, FutureExt};
-use near_async::messaging::IntoMultiSender;
-use near_chain::test_utils::ValidatorSchedule;
-use near_primitives::merkle::PartialMerkleTree;
-use near_primitives::test_utils::create_test_signer;
-use std::time::Duration;
-
 use crate::test_utils::{setup_mock_all_validators, setup_no_network, setup_only_view};
 use crate::{
     GetBlock, GetBlockWithMerkleTree, GetExecutionOutcomesForBlock, Query, QueryError, Status,
     TxStatus,
 };
+use actix::System;
+use futures::{future, FutureExt};
 use near_actix_test_utils::run_actix;
+use near_async::messaging::IntoMultiSender;
+use near_async::time::{Duration, Utc};
+use near_chain::test_utils::ValidatorSchedule;
 use near_chain_configs::DEFAULT_GC_NUM_EPOCHS_TO_KEEP;
 use near_crypto::{InMemorySigner, KeyType};
 use near_network::client::{
@@ -22,14 +19,14 @@ use near_network::types::PeerInfo;
 use near_network::types::{
     NetworkRequests, NetworkResponses, PeerManagerMessageRequest, PeerManagerMessageResponse,
 };
-
-use chrono::Utc;
 use near_o11y::testonly::init_test_logger;
 use near_o11y::WithSpanContextExt;
 use near_primitives::block::{Block, BlockHeader};
+use near_primitives::merkle::PartialMerkleTree;
+use near_primitives::static_clock::StaticClock;
+use near_primitives::test_utils::create_test_signer;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::{BlockId, BlockReference, EpochId};
-use near_primitives::utils::to_timestamp;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{QueryRequest, QueryResponseKind};
 use num_rational::Ratio;
@@ -98,10 +95,10 @@ fn query_status_not_crash() {
                 &signer,
                 block.header.next_bp_hash,
                 block_merkle_tree.root(),
-                None,
+                StaticClock::utc(),
             );
             next_block.mut_header().get_mut().inner_lite.timestamp =
-                to_timestamp(next_block.header().timestamp() + chrono::Duration::seconds(60));
+                (next_block.header().timestamp() + Duration::seconds(60)).unix_timestamp() as u64;
             next_block.mut_header().resign(&signer);
 
             actix::spawn(
@@ -175,7 +172,7 @@ fn test_execution_outcome_for_chunk() {
                 .unwrap();
             assert!(matches!(res, ProcessTxResponse::ValidTx));
 
-            actix::clock::sleep(Duration::from_millis(500)).await;
+            actix::clock::sleep(std::time::Duration::from_millis(500)).await;
             let block_hash = actor_handles
                 .view_client_actor
                 .send(
@@ -227,10 +224,10 @@ fn test_state_request() {
             true,
             MockPeerManagerAdapter::default().into_multi_sender(),
             100,
-            Utc::now(),
+            Utc::now_utc(),
         );
         actix::spawn(async move {
-            actix::clock::sleep(Duration::from_millis(500)).await;
+            actix::clock::sleep(std::time::Duration::from_millis(500)).await;
             let block_hash = view_client
                 .send(GetBlock(BlockReference::BlockId(BlockId::Height(0))).with_span_context())
                 .await
@@ -255,7 +252,7 @@ fn test_state_request() {
                 .await
                 .unwrap();
             assert!(res.is_none());
-            actix::clock::sleep(Duration::from_secs(40)).await;
+            actix::clock::sleep(std::time::Duration::from_secs(40)).await;
             let res = view_client
                 .send(StateRequestHeader { shard_id: 0, sync_hash: block_hash }.with_span_context())
                 .await

--- a/chain/network/src/config_json.rs
+++ b/chain/network/src/config_json.rs
@@ -1,9 +1,9 @@
 use crate::network_protocol::PeerAddr;
 use crate::stun;
-use std::time::Duration;
+use near_async::time::Duration;
 
 /// Time to persist Accounts Id in the router without removing them in seconds.
-pub const TTL_ACCOUNT_ID_ROUTER: u64 = 60 * 60;
+pub const TTL_ACCOUNT_ID_ROUTER: i64 = 60 * 60;
 
 /// Maximum number of active peers. Hard limit.
 fn default_max_num_peers() -> u32 {
@@ -23,7 +23,7 @@ fn default_ideal_connections_hi() -> u32 {
 }
 /// Peers which last message is was within this period of time are considered active recent peers.
 fn default_peer_recent_time_window() -> Duration {
-    Duration::from_secs(600)
+    Duration::seconds(600)
 }
 /// Number of peers to keep while removing a connection.
 /// Used to avoid disconnecting from peers we have been connected since long time.
@@ -37,15 +37,15 @@ fn default_archival_peer_connections_lower_bound() -> u32 {
 }
 /// Time to persist Accounts Id in the router without removing them in seconds.
 fn default_ttl_account_id_router() -> Duration {
-    Duration::from_secs(TTL_ACCOUNT_ID_ROUTER)
+    Duration::seconds(TTL_ACCOUNT_ID_ROUTER)
 }
 /// Period to check on peer status
 fn default_peer_stats_period() -> Duration {
-    Duration::from_secs(5)
+    Duration::seconds(5)
 }
 /// Period to update the list of peers we connect to.
 fn default_monitor_peers_max_period() -> Duration {
-    Duration::from_secs(60)
+    Duration::seconds(60)
 }
 /// Maximum number of peer states to keep in memory.
 fn default_peer_states_cache_size() -> u32 {
@@ -57,7 +57,7 @@ fn default_snapshot_hosts_cache_size() -> u32 {
 }
 /// Remove peers that we didn't hear about for this amount of time.
 fn default_peer_expiration_duration() -> Duration {
-    Duration::from_secs(7 * 24 * 60 * 60)
+    Duration::seconds(7 * 24 * 60 * 60)
 }
 
 /// This is a list of public STUN servers provided by Google,
@@ -205,7 +205,7 @@ fn default_tier1_enable_outbound() -> bool {
 }
 
 fn default_tier1_connect_interval() -> Duration {
-    Duration::from_secs(60)
+    Duration::seconds(60)
 }
 
 fn default_tier1_new_connections_per_attempt() -> u64 {
@@ -296,11 +296,11 @@ impl Default for Config {
             peer_recent_time_window: default_peer_recent_time_window(),
             safe_set_size: default_safe_set_size(),
             archival_peer_connections_lower_bound: default_archival_peer_connections_lower_bound(),
-            handshake_timeout: Duration::from_secs(20),
+            handshake_timeout: Duration::seconds(20),
             skip_sync_wait: false,
             peer_states_cache_size: default_peer_states_cache_size(),
             snapshot_hosts_cache_size: default_snapshot_hosts_cache_size(),
-            ban_window: Duration::from_secs(3 * 60 * 60),
+            ban_window: Duration::seconds(3 * 60 * 60),
             blacklist: vec![],
             ttl_account_id_router: default_ttl_account_id_router(),
             peer_stats_period: default_peer_stats_period(),

--- a/chain/network/src/network_protocol/testonly.rs
+++ b/chain/network/src/network_protocol/testonly.rs
@@ -27,13 +27,11 @@ use std::collections::HashMap;
 use std::net;
 use std::sync::Arc;
 
-pub fn make_genesis_block(_clock: &time::Clock, chunks: Vec<ShardChunk>) -> Block {
+pub fn make_genesis_block(clock: &time::Clock, chunks: Vec<ShardChunk>) -> Block {
     Block::genesis(
         version::PROTOCOL_VERSION,
         chunks.into_iter().map(|c| c.take_header()).collect(),
-        // TODO: this should be clock.now(), but Block::genesis has to be migrated
-        // from chrono to time first.
-        chrono::Utc::now(),
+        clock.now_utc(),
         0,
         1000,
         1000,
@@ -42,7 +40,7 @@ pub fn make_genesis_block(_clock: &time::Clock, chunks: Vec<ShardChunk>) -> Bloc
 }
 
 pub fn make_block(
-    _clock: &time::Clock,
+    clock: &time::Clock,
     signer: &dyn ValidatorSigner,
     prev: &Block,
     chunks: Vec<ShardChunk>,
@@ -68,8 +66,7 @@ pub fn make_block(
         signer,
         CryptoHash::default(),
         CryptoHash::default(),
-        // TODO: migrate to clock.now()
-        Some(chrono::Utc::now()),
+        clock.now_utc(),
     )
 }
 

--- a/chain/network/src/shards_manager.rs
+++ b/chain/network/src/shards_manager.rs
@@ -1,6 +1,5 @@
-use std::time::Instant;
-
 use actix::Message;
+use near_async::time::Instant;
 use near_primitives::{hash::CryptoHash, sharding::PartialEncodedChunk};
 
 use crate::types::{

--- a/chain/telemetry/Cargo.toml
+++ b/chain/telemetry/Cargo.toml
@@ -19,6 +19,7 @@ once_cell.workspace = true
 openssl.workspace = true
 serde.workspace = true
 serde_json.workspace = true
+time.workspace = true
 tracing.workspace = true
 
 near-o11y.workspace = true

--- a/core/async/src/examples/actix_component.rs
+++ b/core/async/src/examples/actix_component.rs
@@ -1,6 +1,7 @@
 use crate as near_async; // only needed because we're in this crate itself
 use crate::futures::{DelayedActionRunner, DelayedActionRunnerExt};
 use crate::messaging::{AsyncSender, SendAsync, Sender};
+use crate::time::Duration;
 use futures::future::BoxFuture;
 use futures::FutureExt;
 use near_async_derive::{MultiSend, MultiSendMessage, MultiSenderFrom};
@@ -49,7 +50,7 @@ impl ExampleComponent {
     }
 
     fn schedule_periodic_request(&mut self, ctx: &mut dyn DelayedActionRunner<Self>) {
-        ctx.run_later("periodic_request", std::time::Duration::from_secs(1), |component, ctx| {
+        ctx.run_later("periodic_request", Duration::seconds(1), |component, ctx| {
             component
                 .periodic_request_sender
                 .send(PeriodicRequest { id: component.next_periodic_request_id });

--- a/core/async/src/test_loop/futures.rs
+++ b/core/async/src/test_loop/futures.rs
@@ -1,5 +1,6 @@
 use super::{delay_sender::DelaySender, event_handler::LoopEventHandler};
 use crate::futures::DelayedActionRunner;
+use crate::time::Duration;
 use crate::{futures::FutureSpawner, messaging::CanSend};
 use futures::future::BoxFuture;
 use futures::task::{waker_ref, ArcWake};
@@ -139,7 +140,7 @@ impl<T> DelayedActionRunner<T> for TestLoopDelayedActionRunner<T> {
     fn run_later_boxed(
         &mut self,
         name: &str,
-        dur: std::time::Duration,
+        dur: Duration,
         action: Box<dyn FnOnce(&mut T, &mut dyn DelayedActionRunner<T>) + Send + 'static>,
     ) {
         self.sender.send_with_delay(

--- a/core/chain-configs/Cargo.toml
+++ b/core/chain-configs/Cargo.toml
@@ -22,6 +22,7 @@ serde.workspace = true
 serde_json.workspace = true
 sha2.workspace = true
 smart-default.workspace = true
+time.workspace = true
 tracing.workspace = true
 
 near-crypto.workspace = true

--- a/core/chain-configs/src/client_config.rs
+++ b/core/chain-configs/src/client_config.rs
@@ -9,9 +9,9 @@ use std::cmp::{max, min};
 use std::path::PathBuf;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use std::time::Duration;
+use time::Duration;
 
-pub const TEST_STATE_SYNC_TIMEOUT: u64 = 5;
+pub const TEST_STATE_SYNC_TIMEOUT: i64 = 5;
 
 #[derive(Debug, Copy, Clone, serde::Serialize, serde::Deserialize)]
 pub enum LogSummaryStyle {
@@ -206,31 +206,31 @@ impl Default for ReshardingConfig {
         // extra load on the node as possible.
         Self {
             batch_size: bytesize::ByteSize::kb(500),
-            batch_delay: Duration::from_millis(100),
-            retry_delay: Duration::from_secs(10),
-            initial_delay: Duration::from_secs(0),
+            batch_delay: Duration::milliseconds(100),
+            retry_delay: Duration::seconds(10),
+            initial_delay: Duration::seconds(0),
             // The snapshot typically is available within a minute from the
             // epoch start. Set the default higher in case we need to wait for
             // state sync.
-            max_poll_time: Duration::from_secs(2 * 60 * 60), // 2 hours
+            max_poll_time: Duration::seconds(2 * 60 * 60), // 2 hours
         }
     }
 }
 
 pub fn default_header_sync_initial_timeout() -> Duration {
-    Duration::from_secs(10)
+    Duration::seconds(10)
 }
 
 pub fn default_header_sync_progress_timeout() -> Duration {
-    Duration::from_secs(2)
+    Duration::seconds(2)
 }
 
 pub fn default_header_sync_stall_ban_timeout() -> Duration {
-    Duration::from_secs(120)
+    Duration::seconds(120)
 }
 
 pub fn default_state_sync_timeout() -> Duration {
-    Duration::from_secs(60)
+    Duration::seconds(60)
 }
 
 pub fn default_header_sync_expected_height_per_second() -> u64 {
@@ -238,11 +238,11 @@ pub fn default_header_sync_expected_height_per_second() -> u64 {
 }
 
 pub fn default_sync_check_period() -> Duration {
-    Duration::from_secs(10)
+    Duration::seconds(10)
 }
 
 pub fn default_sync_step_period() -> Duration {
-    Duration::from_millis(10)
+    Duration::milliseconds(10)
 }
 
 pub fn default_sync_height_threshold() -> u64 {
@@ -274,11 +274,11 @@ pub fn default_view_client_threads() -> usize {
 }
 
 pub fn default_log_summary_period() -> Duration {
-    Duration::from_secs(10)
+    Duration::seconds(10)
 }
 
 pub fn default_view_client_throttle_period() -> Duration {
-    Duration::from_secs(30)
+    Duration::seconds(30)
 }
 
 pub fn default_trie_viewer_state_size_limit() -> Option<u64> {
@@ -298,7 +298,7 @@ pub fn default_enable_multiline_logging() -> Option<bool> {
 }
 
 pub fn default_produce_chunk_add_transactions_time_limit() -> Option<Duration> {
-    Some(Duration::from_millis(200))
+    Some(Duration::milliseconds(200))
 }
 
 pub fn default_orphan_state_witness_pool_size() -> usize {
@@ -476,35 +476,35 @@ impl ClientConfig {
             chain_id: "unittest".to_string(),
             rpc_addr: Some("0.0.0.0:3030".to_string()),
             expected_shutdown: MutableConfigValue::new(None, "expected_shutdown"),
-            block_production_tracking_delay: Duration::from_millis(std::cmp::max(
+            block_production_tracking_delay: Duration::milliseconds(std::cmp::max(
                 10,
                 min_block_prod_time / 5,
-            )),
-            min_block_production_delay: Duration::from_millis(min_block_prod_time),
-            max_block_production_delay: Duration::from_millis(max_block_prod_time),
-            max_block_wait_delay: Duration::from_millis(3 * min_block_prod_time),
+            ) as i64),
+            min_block_production_delay: Duration::milliseconds(min_block_prod_time as i64),
+            max_block_production_delay: Duration::milliseconds(max_block_prod_time as i64),
+            max_block_wait_delay: Duration::milliseconds(3 * min_block_prod_time as i64),
             skip_sync_wait,
-            sync_check_period: Duration::from_millis(100),
-            sync_step_period: Duration::from_millis(10),
+            sync_check_period: Duration::milliseconds(100),
+            sync_step_period: Duration::milliseconds(10),
             sync_height_threshold: 1,
-            header_sync_initial_timeout: Duration::from_secs(10),
-            header_sync_progress_timeout: Duration::from_secs(2),
-            header_sync_stall_ban_timeout: Duration::from_secs(30),
-            state_sync_timeout: Duration::from_secs(TEST_STATE_SYNC_TIMEOUT),
+            header_sync_initial_timeout: Duration::seconds(10),
+            header_sync_progress_timeout: Duration::seconds(2),
+            header_sync_stall_ban_timeout: Duration::seconds(30),
+            state_sync_timeout: Duration::seconds(TEST_STATE_SYNC_TIMEOUT),
             header_sync_expected_height_per_second: 1,
             min_num_peers: 1,
-            log_summary_period: Duration::from_secs(10),
+            log_summary_period: Duration::seconds(10),
             produce_empty_blocks: true,
             epoch_length: 10,
             num_block_producer_seats,
-            ttl_account_id_router: Duration::from_secs(60 * 60),
+            ttl_account_id_router: Duration::seconds(60 * 60),
             block_fetch_horizon: 50,
-            catchup_step_period: Duration::from_millis(100),
+            catchup_step_period: Duration::milliseconds(100),
             chunk_request_retry_period: min(
-                Duration::from_millis(100),
-                Duration::from_millis(min_block_prod_time / 5),
+                Duration::milliseconds(100),
+                Duration::milliseconds(min_block_prod_time as i64 / 5),
             ),
-            doosmslug_step_period: Duration::from_millis(100),
+            doosmslug_step_period: Duration::milliseconds(100),
             block_header_fetch_horizon: 50,
             gc: GCConfig { gc_blocks_limit: 100, ..GCConfig::default() },
             tracked_accounts: vec![],
@@ -515,13 +515,13 @@ impl ClientConfig {
             log_summary_style: LogSummaryStyle::Colored,
             view_client_threads: 1,
             epoch_sync_enabled,
-            view_client_throttle_period: Duration::from_secs(1),
+            view_client_throttle_period: Duration::seconds(1),
             trie_viewer_state_size_limit: None,
             max_gas_burnt_view: None,
             enable_statistics_export: true,
             client_background_migration_threads: 1,
             flat_storage_creation_enabled: true,
-            flat_storage_creation_period: Duration::from_secs(1),
+            flat_storage_creation_period: Duration::seconds(1),
             state_sync_enabled,
             state_sync: StateSyncConfig::default(),
             transaction_pool_size_limit: None,

--- a/core/chain-configs/src/test_utils.rs
+++ b/core/chain-configs/src/test_utils.rs
@@ -1,4 +1,5 @@
 use near_primitives::static_clock::StaticClock;
+use near_primitives::utils::from_timestamp;
 use near_primitives::version::PROTOCOL_VERSION;
 use num_rational::Ratio;
 
@@ -7,7 +8,7 @@ use crate::GenesisConfig;
 impl GenesisConfig {
     pub fn test() -> Self {
         GenesisConfig {
-            genesis_time: StaticClock::utc(),
+            genesis_time: from_timestamp(StaticClock::utc().unix_timestamp() as u64),
             genesis_height: 0,
             gas_limit: 10u64.pow(15),
             min_gas_price: 0,

--- a/core/chain-configs/src/updateable_config.rs
+++ b/core/chain-configs/src/updateable_config.rs
@@ -1,7 +1,8 @@
 use near_primitives::types::BlockHeight;
 use serde::{Deserialize, Serialize, Serializer};
+use std::fmt::Debug;
 use std::sync::{Arc, Mutex};
-use std::{fmt::Debug, time::Duration};
+use time::{Duration, OffsetDateTime as Utc};
 
 use crate::ReshardingConfig;
 
@@ -18,7 +19,7 @@ pub struct MutableConfigValue<T> {
     #[cfg(feature = "metrics")]
     // For metrics.
     // Mutable config values are exported to prometheus with labels [field_name][last_update][value].
-    last_update: chrono::DateTime<chrono::Utc>,
+    last_update: Utc,
 }
 
 impl<T: Serialize> Serialize for MutableConfigValue<T> {
@@ -76,7 +77,7 @@ impl<T: Copy + PartialEq + Debug> MutableConfigValue<T> {
         crate::metrics::CONFIG_MUTABLE_FIELD
             .with_label_values(&[
                 &self.field_name,
-                &self.last_update.timestamp().to_string(),
+                &self.last_update.unix_timestamp().to_string(),
                 &format!("{:?}", value),
             ])
             .set(metric_value);

--- a/core/dyn-configs/src/lib.rs
+++ b/core/dyn-configs/src/lib.rs
@@ -68,7 +68,7 @@ impl UpdateableConfigLoader {
     }
 
     fn update_metrics() {
-        metrics::CONFIG_RELOAD_TIMESTAMP.set(StaticClock::utc().timestamp());
+        metrics::CONFIG_RELOAD_TIMESTAMP.set(StaticClock::utc().unix_timestamp());
         metrics::CONFIG_RELOADS.inc();
     }
 }

--- a/core/primitives/benches/serialization.rs
+++ b/core/primitives/benches/serialization.rs
@@ -69,7 +69,7 @@ fn create_block() -> Block {
         &signer,
         CryptoHash::default(),
         CryptoHash::default(),
-        None,
+        StaticClock::utc(),
     )
 }
 

--- a/core/primitives/src/block.rs
+++ b/core/primitives/src/block.rs
@@ -13,18 +13,16 @@ use crate::sharding::{
     ChunkHashHeight, EncodedShardChunk, ReedSolomonWrapper, ShardChunk, ShardChunkHeader,
     ShardChunkHeaderV1,
 };
-use crate::static_clock::StaticClock;
 use crate::types::{Balance, BlockHeight, EpochId, Gas, NumBlocks, StateRoot};
-use crate::utils::to_timestamp;
 use crate::validator_signer::{EmptyValidatorSigner, ValidatorSigner};
 use crate::version::{ProtocolVersion, SHARD_CHUNK_HEADER_UPGRADE_VERSION};
 use borsh::{BorshDeserialize, BorshSerialize};
-use chrono::{DateTime, Utc};
 use near_crypto::Signature;
 use near_primitives_core::types::ShardId;
 use primitive_types::U256;
 use std::ops::Index;
 use std::sync::Arc;
+use time::OffsetDateTime as Utc;
 
 #[derive(BorshSerialize, BorshDeserialize, Clone, Debug, Eq, PartialEq, Default)]
 pub struct GenesisId {
@@ -197,7 +195,7 @@ impl Block {
     pub fn genesis(
         genesis_protocol_version: ProtocolVersion,
         chunks: Vec<ShardChunkHeader>,
-        timestamp: DateTime<Utc>,
+        timestamp: Utc,
         height: BlockHeight,
         initial_gas_price: Balance,
         initial_total_supply: Balance,
@@ -264,7 +262,7 @@ impl Block {
         signer: &dyn ValidatorSigner,
         next_bp_hash: CryptoHash,
         block_merkle_root: CryptoHash,
-        timestamp_override: Option<DateTime<chrono::Utc>>,
+        timestamp: Utc,
     ) -> Self {
         // Collect aggregate of validators and gas usage/limits from chunks.
         let mut prev_validator_proposals = vec![];
@@ -294,7 +292,7 @@ impl Block {
         );
 
         let new_total_supply = prev.total_supply() + minted_amount.unwrap_or(0) - balance_burnt;
-        let now = to_timestamp(timestamp_override.unwrap_or_else(StaticClock::utc));
+        let now = timestamp.unix_timestamp() as u64;
         let time = if now <= prev.raw_timestamp() { prev.raw_timestamp() + 1 } else { now };
 
         let (vrf_value, vrf_proof) = signer.compute_vrf_with_proof(prev.random_value().as_ref());

--- a/core/primitives/src/block_header.rs
+++ b/core/primitives/src/block_header.rs
@@ -4,13 +4,12 @@ use crate::merkle::combine_hash;
 use crate::network::PeerId;
 use crate::types::validator_stake::{ValidatorStake, ValidatorStakeIter, ValidatorStakeV1};
 use crate::types::{AccountId, Balance, BlockHeight, EpochId, MerkleHash, NumBlocks};
-use crate::utils::{from_timestamp, to_timestamp};
 use crate::validator_signer::ValidatorSigner;
 use crate::version::{get_protocol_version, ProtocolVersion, PROTOCOL_VERSION};
 use borsh::{BorshDeserialize, BorshSerialize};
-use chrono::{DateTime, Utc};
 use near_crypto::{KeyType, PublicKey, Signature};
 use std::sync::Arc;
+use time::OffsetDateTime as Utc;
 
 #[derive(
     BorshSerialize, BorshDeserialize, serde::Serialize, Debug, Clone, Eq, PartialEq, Default,
@@ -600,7 +599,7 @@ impl BlockHeader {
         chunk_tx_root: MerkleHash,
         num_shards: u64,
         challenges_root: MerkleHash,
-        timestamp: DateTime<Utc>,
+        timestamp: Utc,
         initial_gas_price: Balance,
         initial_total_supply: Balance,
         next_bp_hash: CryptoHash,
@@ -612,7 +611,7 @@ impl BlockHeader {
             next_epoch_id: EpochId::default(),
             prev_state_root: state_root,
             prev_outcome_root: CryptoHash::default(),
-            timestamp: to_timestamp(timestamp),
+            timestamp: timestamp.unix_timestamp() as u64,
             next_bp_hash,
             block_merkle_root: CryptoHash::default(),
         };
@@ -1061,8 +1060,8 @@ impl BlockHeader {
         self.signature().verify(self.hash().as_ref(), public_key)
     }
 
-    pub fn timestamp(&self) -> DateTime<Utc> {
-        from_timestamp(self.raw_timestamp())
+    pub fn timestamp(&self) -> Utc {
+        Utc::from_unix_timestamp(self.raw_timestamp() as i64).unwrap()
     }
 
     pub fn num_approvals(&self) -> u64 {

--- a/core/primitives/src/static_clock.rs
+++ b/core/primitives/src/static_clock.rs
@@ -27,18 +27,16 @@
 ///     some_production_function();
 /// }
 /// ```
-use chrono;
-use chrono::DateTime;
-use chrono::Utc;
 use std::cell::RefCell;
 use std::collections::VecDeque;
 use std::default::Default;
-use std::time::Instant;
+use time::Instant;
+use time::OffsetDateTime as Utc;
 
 #[derive(Default)]
 struct MockClockPerState {
     /// List of timestamps, we will return one timestamp for each call of `Clock::utc()`.
-    utc_list: VecDeque<DateTime<Utc>>,
+    utc_list: VecDeque<Utc>,
     /// List of timestamps, we will return one timestamp to each call of `Clock::instant()`.
     instant_list: VecDeque<Instant>,
     /// Number of times `Clock::utc()` method was called since we started mocking.
@@ -69,7 +67,7 @@ pub struct MockClockGuard {}
 
 impl MockClockGuard {
     /// Adds timestamp to queue, it will be returned in `Self::utc()`.
-    pub fn add_utc(&self, mock_date: DateTime<chrono::Utc>) {
+    pub fn add_utc(&self, mock_date: Utc) {
         MockClockPerThread::with(|clock| match &mut clock.mock {
             Some(clock) => {
                 clock.utc_list.push_back(mock_date);
@@ -163,7 +161,7 @@ impl StaticClock {
 
     /// This methods gets current time as `std::Instant`
     /// unless it's mocked, then returns time added by `Self::add_instant(...)`
-    pub fn utc() -> DateTime<chrono::Utc> {
+    pub fn utc() -> Utc {
         MockClockPerThread::with(|clock| match &mut clock.mock {
             Some(clock) => {
                 clock.utc_call_count += 1;
@@ -175,7 +173,7 @@ impl StaticClock {
                     }
                 }
             }
-            None => chrono::Utc::now(),
+            None => Utc::now_utc(),
         })
     }
 }

--- a/core/primitives/src/test_utils.rs
+++ b/core/primitives/src/test_utils.rs
@@ -1,11 +1,3 @@
-use std::collections::HashMap;
-use std::sync::Arc;
-
-use near_crypto::vrf::Value;
-use near_crypto::{EmptySigner, InMemorySigner, KeyType, PublicKey, SecretKey, Signature, Signer};
-use near_primitives_core::account::id::AccountIdRef;
-use near_primitives_core::types::ProtocolVersion;
-
 use crate::account::{AccessKey, AccessKeyPermission, Account};
 use crate::block::Block;
 use crate::block_body::{BlockBody, ChunkEndorsementSignatures};
@@ -16,6 +8,7 @@ use crate::hash::CryptoHash;
 use crate::merkle::PartialMerkleTree;
 use crate::num_rational::Ratio;
 use crate::sharding::{ShardChunkHeader, ShardChunkHeaderV3};
+use crate::static_clock::StaticClock;
 use crate::transaction::{
     Action, AddKeyAction, CreateAccountAction, DeleteAccountAction, DeleteKeyAction,
     DeployContractAction, FunctionCallAction, SignedTransaction, StakeAction, Transaction,
@@ -25,6 +18,12 @@ use crate::types::{AccountId, Balance, EpochId, EpochInfoProvider, Gas, Nonce};
 use crate::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
 use crate::version::PROTOCOL_VERSION;
 use crate::views::{ExecutionStatusView, FinalExecutionOutcomeView, FinalExecutionStatus};
+use near_crypto::vrf::Value;
+use near_crypto::{EmptySigner, InMemorySigner, KeyType, PublicKey, SecretKey, Signature, Signer};
+use near_primitives_core::account::id::AccountIdRef;
+use near_primitives_core::types::ProtocolVersion;
+use std::collections::HashMap;
+use std::sync::Arc;
 
 pub fn account_new(amount: Balance, code_hash: CryptoHash) -> Account {
     Account::new(amount, 0, 0, code_hash, std::mem::size_of::<Account>() as u64, PROTOCOL_VERSION)
@@ -463,7 +462,7 @@ impl TestBlockBuilder {
             self.signer.as_ref(),
             self.next_bp_hash,
             self.block_merkle_root,
-            None,
+            StaticClock::utc(),
         )
     }
 }

--- a/core/primitives/src/views.rs
+++ b/core/primitives/src/views.rs
@@ -39,7 +39,6 @@ use crate::types::{
 };
 use crate::version::{ProtocolVersion, Version};
 use borsh::{BorshDeserialize, BorshSerialize};
-use chrono::DateTime;
 use near_crypto::{PublicKey, Signature};
 use near_fmt::{AbbrBytes, Slice};
 use near_parameters::{ActionCosts, ExtCosts};
@@ -51,6 +50,7 @@ use std::fmt;
 use std::ops::Range;
 use std::sync::Arc;
 use strum::IntoEnumIterator;
+use time::OffsetDateTime as Utc;
 use validator_stake_view::ValidatorStakeView;
 
 /// A view of the account
@@ -351,11 +351,11 @@ pub struct StatusSyncInfo {
     pub latest_block_hash: CryptoHash,
     pub latest_block_height: BlockHeight,
     pub latest_state_root: CryptoHash,
-    pub latest_block_time: DateTime<chrono::Utc>,
+    pub latest_block_time: Utc,
     pub syncing: bool,
     pub earliest_block_hash: Option<CryptoHash>,
     pub earliest_block_height: Option<BlockHeight>,
-    pub earliest_block_time: Option<DateTime<chrono::Utc>>,
+    pub earliest_block_time: Option<Utc>,
     pub epoch_id: Option<EpochId>,
     pub epoch_start_height: Option<BlockHeight>,
 }
@@ -407,7 +407,7 @@ pub struct AccountDataView {
     pub peer_id: PublicKey,
     pub proxies: Vec<Tier1ProxyView>,
     pub account_key: PublicKey,
-    pub timestamp: DateTime<chrono::Utc>,
+    pub timestamp: Utc,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
@@ -588,9 +588,9 @@ pub struct ChainProcessingInfo {
 pub struct BlockProcessingInfo {
     pub height: BlockHeight,
     pub hash: CryptoHash,
-    pub received_timestamp: DateTime<chrono::Utc>,
+    pub received_timestamp: Utc,
     /// Timestamp when block was received.
-    //pub received_timestamp: DateTime<chrono::Utc>,
+    //pub received_timestamp: Utc,
     /// Time (in ms) between when the block was first received and when it was processed
     pub in_progress_ms: u128,
     /// Time (in ms) that the block spent in the orphan pool. If the block was never put in the
@@ -655,9 +655,9 @@ pub struct ChunkProcessingInfo {
     pub created_by: Option<AccountId>,
     pub status: ChunkProcessingStatus,
     /// Timestamp of first time when we request for this chunk.
-    pub requested_timestamp: Option<DateTime<chrono::Utc>>,
+    pub requested_timestamp: Option<Utc>,
     /// Timestamp of when the chunk is complete
-    pub completed_timestamp: Option<DateTime<chrono::Utc>>,
+    pub completed_timestamp: Option<Utc>,
     /// Time (in millis) that it takes between when the chunk is requested and when it is completed.
     pub request_duration: Option<u64>,
     pub chunk_parts_collection: Vec<PartCollectionInfo>,
@@ -667,11 +667,11 @@ pub struct ChunkProcessingInfo {
 pub struct PartCollectionInfo {
     pub part_owner: AccountId,
     // Time when the part is received through any message
-    pub received_time: Option<DateTime<chrono::Utc>>,
+    pub received_time: Option<Utc>,
     // Time when we receive a PartialEncodedChunkForward containing this part
-    pub forwarded_received_time: Option<DateTime<chrono::Utc>>,
+    pub forwarded_received_time: Option<Utc>,
     // Time when we receive the PartialEncodedChunk message containing this part
-    pub chunk_received_time: Option<DateTime<chrono::Utc>>,
+    pub chunk_received_time: Option<Utc>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]

--- a/core/store/Cargo.toml
+++ b/core/store/Cargo.toml
@@ -40,6 +40,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tracing.workspace = true
 
+near-async.workspace = true
 near-chain-configs = { workspace = true, features = ["metrics"] }
 near-crypto.workspace = true
 near-fmt.workspace = true

--- a/core/store/src/config.rs
+++ b/core/store/src/config.rs
@@ -2,8 +2,8 @@ use crate::trie::{
     DEFAULT_SHARD_CACHE_DELETIONS_QUEUE_CAPACITY, DEFAULT_SHARD_CACHE_TOTAL_SIZE_LIMIT,
 };
 use crate::DBCol;
+use near_async::time::Duration;
 use near_primitives::shard_layout::ShardUId;
-use std::time::Duration;
 use std::{collections::HashMap, iter::FromIterator};
 
 #[derive(Clone, Debug, serde::Serialize, serde::Deserialize)]
@@ -294,7 +294,7 @@ impl Default for StoreConfig {
             // we do several disk reads from `FlatStateMisc` and `FlatStateDeltas`.
             // One second should be enough to save deltas on start and catch up
             // flat storage head quickly. State read work is much more expensive.
-            flat_storage_creation_period: Duration::from_secs(1),
+            flat_storage_creation_period: Duration::seconds(1),
 
             state_snapshot_config: Default::default(),
 

--- a/core/store/src/metrics.rs
+++ b/core/store/src/metrics.rs
@@ -1,6 +1,7 @@
 use crate::rocksdb_metrics::export_stats_as_metrics;
 use crate::{NodeStorage, Store, Temperature};
 use actix_rt::ArbiterHandle;
+use near_async::time::Duration;
 use near_o11y::metrics::{
     exponential_buckets, try_create_histogram, try_create_histogram_vec,
     try_create_histogram_with_buckets, try_create_int_counter_vec, try_create_int_gauge,
@@ -559,13 +560,13 @@ fn export_store_stats(store: &Store, temperature: Temperature) {
 
 pub fn spawn_db_metrics_loop(
     storage: &NodeStorage,
-    period: std::time::Duration,
+    period: Duration,
 ) -> anyhow::Result<ArbiterHandle> {
     tracing::debug!(target:"metrics", "Spawning the db metrics loop.");
     let db_metrics_arbiter = actix_rt::Arbiter::new();
 
     let start = tokio::time::Instant::now();
-    let mut interval = actix_rt::time::interval_at(start, period);
+    let mut interval = actix_rt::time::interval_at(start, period.unsigned_abs());
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     let hot_store = storage.get_hot_store();
@@ -588,14 +589,11 @@ pub fn spawn_db_metrics_loop(
 
 #[cfg(test)]
 mod test {
-    use std::time::Duration;
-
-    use actix;
-
     use crate::db::{StatsValue, StoreStatistics};
     use crate::metadata::{DbKind, DB_VERSION};
     use crate::test_utils::create_test_node_storage_with_cold;
-
+    use actix;
+    use near_async::time::Duration;
     use near_o11y::testonly::init_test_logger;
 
     use super::spawn_db_metrics_loop;
@@ -606,7 +604,7 @@ mod test {
 
     async fn test_db_metrics_loop_impl() -> anyhow::Result<()> {
         let (storage, hot, cold) = create_test_node_storage_with_cold(DB_VERSION, DbKind::Cold);
-        let period = Duration::from_millis(100);
+        let period = Duration::milliseconds(100);
 
         let handle = spawn_db_metrics_loop(&storage, period)?;
 
@@ -622,7 +620,7 @@ mod test {
         hot.set_store_statistics(hot_stats);
         cold.set_store_statistics(cold_stats);
 
-        actix::clock::sleep(period).await;
+        actix::clock::sleep(period.unsigned_abs()).await;
         for _ in 0..10 {
             let int_gauges = crate::rocksdb_metrics::get_int_gauges();
 
@@ -631,7 +629,7 @@ mod test {
             if has_hot_gauge && has_cold_gauge {
                 break;
             }
-            actix::clock::sleep(period / 10).await;
+            actix::clock::sleep(period.unsigned_abs() / 10).await;
         }
 
         let int_gauges = crate::rocksdb_metrics::get_int_gauges();

--- a/genesis-tools/genesis-populate/Cargo.toml
+++ b/genesis-tools/genesis-populate/Cargo.toml
@@ -18,6 +18,7 @@ indicatif.workspace = true
 tempfile.workspace = true
 
 nearcore.workspace = true
+near-async.workspace = true
 near-chain-configs.workspace = true
 near-crypto.workspace = true
 near-epoch-manager.workspace = true

--- a/genesis-tools/genesis-populate/src/lib.rs
+++ b/genesis-tools/genesis-populate/src/lib.rs
@@ -4,6 +4,7 @@ pub mod state_dump;
 
 use crate::state_dump::StateDump;
 use indicatif::{ProgressBar, ProgressStyle};
+use near_async::time::Utc;
 use near_chain::types::RuntimeAdapter;
 use near_chain::{Block, Chain, ChainStore};
 use near_chain_configs::Genesis;
@@ -17,6 +18,7 @@ use near_primitives::shard_layout::{account_id_to_shard_id, ShardUId};
 use near_primitives::state_record::StateRecord;
 use near_primitives::types::chunk_extra::ChunkExtra;
 use near_primitives::types::{AccountId, Balance, EpochId, ShardId, StateChangeCause, StateRoot};
+use near_primitives::utils::to_timestamp;
 use near_store::genesis::{compute_storage_usage, initialize_genesis_state};
 use near_store::{
     get_account, get_genesis_state_roots, set_access_key, set_account, set_code, Store, TrieUpdate,
@@ -215,7 +217,8 @@ impl GenesisBuilder {
         let genesis = Block::genesis(
             self.genesis.config.protocol_version,
             genesis_chunks.into_iter().map(|chunk| chunk.take_header()).collect(),
-            self.genesis.config.genesis_time,
+            Utc::from_unix_timestamp(to_timestamp(self.genesis.config.genesis_time) as i64)
+                .unwrap(),
             self.genesis.config.genesis_height,
             self.genesis.config.min_gas_price,
             self.genesis.config.total_supply,

--- a/integration-tests/src/nearcore_utils.rs
+++ b/integration-tests/src/nearcore_utils.rs
@@ -11,6 +11,7 @@ use near_primitives::block::Approval;
 use near_primitives::hash::CryptoHash;
 use near_primitives::merkle::PartialMerkleTree;
 use near_primitives::num_rational::{Ratio, Rational32};
+use near_primitives::static_clock::StaticClock;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{BlockHeightDelta, EpochId};
 use near_primitives::validator_signer::ValidatorSigner;
@@ -81,7 +82,7 @@ pub fn add_blocks(
             signer,
             next_bp_hash,
             block_merkle_tree.root(),
-            None,
+            StaticClock::utc(),
         );
         block_merkle_tree.insert(*block.hash());
         let _ = client.do_send(

--- a/integration-tests/src/tests/client/challenges.rs
+++ b/integration-tests/src/tests/client/challenges.rs
@@ -17,6 +17,7 @@ use near_primitives::num_rational::Ratio;
 use near_primitives::shard_layout::ShardUId;
 use near_primitives::sharding::{EncodedShardChunk, ReedSolomonWrapper};
 use near_primitives::stateless_validation::ChunkEndorsement;
+use near_primitives::static_clock::StaticClock;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::transaction::SignedTransaction;
 use near_primitives::types::chunk_extra::ChunkExtra;
@@ -114,7 +115,7 @@ fn test_verify_block_double_sign_challenge() {
         &signer,
         *b1.header().next_bp_hash(),
         block_merkle_tree.root(),
-        None,
+        StaticClock::utc(),
     );
     let epoch_id = b1.header().epoch_id().clone();
     let valid_challenge = Challenge::produce(
@@ -429,7 +430,7 @@ fn test_verify_chunk_invalid_state_challenge() {
         &validator_signer,
         *last_block.header().next_bp_hash(),
         block_merkle_tree.root(),
-        None,
+        StaticClock::utc(),
     );
 
     let challenge_body =

--- a/integration-tests/src/tests/client/features/simple_test_loop_example.rs
+++ b/integration-tests/src/tests/client/features/simple_test_loop_example.rs
@@ -1,14 +1,18 @@
 use derive_enum_from_into::{EnumFrom, EnumTryInto};
 use near_async::futures::DelayedActionRunnerExt;
-use near_async::messaging::{noop, IntoMultiSender, IntoSender, MessageWithCallback};
-use near_async::test_loop::event_handler::ignore_events;
+use near_async::messaging::{noop, IntoMultiSender, IntoSender};
 use near_async::test_loop::futures::{
     drive_delayed_action_runners, drive_futures, TestLoopDelayedActionEvent, TestLoopTask,
 };
 use near_async::test_loop::TestLoopBuilder;
+use near_async::time::Duration;
+use near_chain::chunks_store::ReadOnlyChunksStore;
 use near_chain::ChainGenesis;
 use near_chain_configs::{ClientConfig, Genesis, GenesisConfig, GenesisRecords};
 use near_chunks::adapter::ShardsManagerRequestFromClient;
+use near_chunks::client::ShardsManagerResponse;
+use near_chunks::test_loop::forward_client_request_to_shards_manager;
+use near_chunks::ShardsManager;
 use near_client::client_actions::{
     ClientActions, ClientSenderForClientMessage, SyncJobsSenderForClientMessage,
 };
@@ -17,6 +21,7 @@ use near_client::sync_jobs_actions::{
 };
 use near_client::test_utils::client_actions_test_utils::{
     forward_client_messages_from_client_to_client_actions,
+    forward_client_messages_from_shards_manager,
     forward_client_messages_from_sync_jobs_to_client_actions,
 };
 use near_client::test_utils::sync_jobs_test_utils::forward_sync_jobs_messages_from_client_to_sync_jobs_actions;
@@ -25,7 +30,6 @@ use near_client::{Client, SyncAdapter, SyncMessage};
 use near_epoch_manager::shard_tracker::{ShardTracker, TrackedConfig};
 use near_epoch_manager::EpochManager;
 use near_network::client::ClientSenderForNetworkMessage;
-use near_network::types::{PeerManagerMessageRequest, PeerManagerMessageResponse, SetChainInfo};
 use near_primitives::network::PeerId;
 use near_primitives::shard_layout::ShardLayout;
 use near_primitives::state_record::StateRecord;
@@ -39,13 +43,13 @@ use near_store::test_utils::create_test_store;
 use nearcore::NightshadeRuntime;
 use std::path::Path;
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
 
 #[derive(derive_more::AsMut, derive_more::AsRef)]
 struct TestData {
     pub dummy: (),
     pub client: ClientActions,
     pub sync_jobs: SyncJobsActions,
+    pub shards_manager: ShardsManager,
 }
 
 #[derive(EnumTryInto, Debug, EnumFrom)]
@@ -56,15 +60,11 @@ enum TestEvent {
     ClientEventFromNetwork(ClientSenderForNetworkMessage),
     ClientEventFromClient(ClientSenderForClientMessage),
     ClientEventFromSyncJobs(ClientSenderForSyncJobsMessage),
+    ClientEventFromShardsManager(ShardsManagerResponse),
     SyncJobsEventFromClient(SyncJobsSenderForClientMessage),
     SyncJobsEventFromSyncJobs(SyncJobsSenderForSyncJobsMessage),
     ShardsManagerRequestFromClient(ShardsManagerRequestFromClient),
     ClientEventFromStateSyncAdapter(SyncMessage),
-    NetworkMessage(PeerManagerMessageRequest),
-    NetworkMessageForResponse(
-        MessageWithCallback<PeerManagerMessageRequest, PeerManagerMessageResponse>,
-    ),
-    NetworkSetChainInfo(SetChainInfo),
 }
 
 const ONE_NEAR: u128 = 1_000_000_000_000_000_000_000_000;
@@ -81,8 +81,8 @@ fn test_client_with_simple_test_loop() {
     );
     let client_config = ClientConfig::test(
         true,
-        MIN_BLOCK_PROD_TIME.as_nanos() as u64,
-        MAX_BLOCK_PROD_TIME.as_nanos() as u64,
+        MIN_BLOCK_PROD_TIME.whole_milliseconds() as u64,
+        MAX_BLOCK_PROD_TIME.whole_milliseconds() as u64,
         4,
         false,
         true,
@@ -93,15 +93,11 @@ fn test_client_with_simple_test_loop() {
     let initial_balance = 10000 * ONE_NEAR;
     let accounts =
         (0..100).map(|i| format!("account{}", i).parse().unwrap()).collect::<Vec<AccountId>>();
+
+    // TODO: Make some builder for genesis.
     let mut genesis_config = GenesisConfig {
-        // Use the latest protocol version. Otherwise, the version may be too
-        // old that e.g. blocks don't even store previous heights.
         protocol_version: PROTOCOL_VERSION,
-        // Some arbitrary starting height. Doesn't matter.
         genesis_height: 10000,
-        // We'll test with 4 shards. This can be any number, but we want to test
-        // the case when some shards are loaded into memory and others are not.
-        // We pick the boundaries so that each shard would get some transactions.
         shard_layout: ShardLayout::v1(
             vec!["account3", "account5", "account7"]
                 .into_iter()
@@ -110,57 +106,26 @@ fn test_client_with_simple_test_loop() {
             None,
             1,
         ),
-        // We're going to send NEAR between accounts and then assert at the end
-        // that these transactions have been processed correctly, so here we set
-        // the gas price to 0 so that we don't have to calculate gas cost.
         min_gas_price: 0,
         max_gas_price: 0,
-        // Set the block gas limit high enough so we don't have to worry about
-        // transactions being throttled.
         gas_limit: 100000000000000,
-        // Set the validity period high enough so even if a transaction gets
-        // included a few blocks later it won't be rejected.
         transaction_validity_period: 1000,
-        // Make two validators. In this test we don't care about validators but
-        // the TestEnv framework works best if all clients are validators. So
-        // since we are using two clients, make two validators.
-        validators: vec![
-            AccountInfo {
-                account_id: accounts[0].clone(),
-                amount: validator_stake,
-                public_key: create_test_signer(accounts[0].as_str()).public_key(),
-            },
-            AccountInfo {
-                account_id: accounts[1].clone(),
-                amount: validator_stake,
-                public_key: create_test_signer(accounts[1].as_str()).public_key(),
-            },
-        ],
-        // We don't care about epoch transitions in this test, and epoch
-        // transitions means validator selection, which can kick out validators
-        // (due to our test purposefully skipping blocks to create forks), and
-        // that's annoying to deal with. So set this to a high value to stay
-        // within a single epoch.
-        epoch_length: 10000,
-        // The genesis requires this, so set it to something arbitrary.
+        validators: vec![AccountInfo {
+            account_id: accounts[0].clone(),
+            amount: validator_stake,
+            public_key: create_test_signer(accounts[0].as_str()).public_key(),
+        }],
+        epoch_length: 10,
         protocol_treasury_account: accounts[2].clone(),
-        // Simply make all validators block producers.
-        num_block_producer_seats: 2,
-        // Make all validators produce chunks for all shards.
-        minimum_validators_per_shard: 2,
-        // Even though not used for the most recent protocol version,
-        // this must still have the same length as the number of shards,
-        // or else the genesis fails validation.
-        num_block_producer_seats_per_shard: vec![2, 2, 2, 2],
+        num_block_producer_seats: 1,
+        minimum_validators_per_shard: 1,
+        num_block_producer_seats_per_shard: vec![1, 1, 1, 1],
         ..Default::default()
     };
-    // We'll now create the initial records. We'll set up 100 accounts, each
-    // with some initial balance. We'll add an access key to each account so
-    // we can send transactions from them.
     let mut records = Vec::new();
     for (i, account) in accounts.iter().enumerate() {
         // The staked amount must be consistent with validators from genesis.
-        let staked = if i < 2 { validator_stake } else { 0 };
+        let staked = if i < 1 { validator_stake } else { 0 };
         records.push(StateRecord::Account {
             account_id: account.clone(),
             account: Account::new(
@@ -190,26 +155,43 @@ fn test_client_with_simple_test_loop() {
     let shard_tracker = ShardTracker::new(TrackedConfig::AllShards, epoch_manager.clone());
     let state_sync_adapter = Arc::new(RwLock::new(SyncAdapter::new(
         builder.sender().into_sender(),
-        builder.sender().into_sender(),
+        noop().into_sender(),
     )));
-    let runtime_adapter =
-        NightshadeRuntime::test(Path::new("."), store, &genesis.config, epoch_manager.clone());
+    let runtime_adapter = NightshadeRuntime::test(
+        Path::new("."),
+        store.clone(),
+        &genesis.config,
+        epoch_manager.clone(),
+    );
 
     let client = Client::new(
+        builder.clock(),
         client_config.clone(),
         chain_genesis,
-        epoch_manager,
-        shard_tracker,
+        epoch_manager.clone(),
+        shard_tracker.clone(),
         state_sync_adapter,
         runtime_adapter,
-        builder.sender().into_multi_sender(),
+        noop().into_multi_sender(),
         builder.sender().into_sender(),
-        None,
+        Some(Arc::new(create_test_signer(accounts[0].as_str()))),
         true,
         [0; 32],
         None,
     )
     .unwrap();
+
+    let shards_manager = ShardsManager::new(
+        builder.clock(),
+        Some(accounts[0].clone()),
+        epoch_manager,
+        shard_tracker,
+        noop().into_sender(),
+        builder.sender().into_sender(),
+        ReadOnlyChunksStore::new(store),
+        client.chain.head().unwrap(),
+        client.chain.header_head().unwrap(),
+    );
 
     let client_actions = ClientActions::new(
         builder.clock(),
@@ -217,7 +199,7 @@ fn test_client_with_simple_test_loop() {
         builder.wrapped_multi_sender::<ClientSenderForClientMessage, _>(),
         client_config,
         PeerId::random(),
-        builder.sender().into_multi_sender(),
+        noop().into_multi_sender(),
         None,
         noop().into_sender(),
         None,
@@ -228,17 +210,23 @@ fn test_client_with_simple_test_loop() {
     )
     .unwrap();
 
-    let data = TestData { dummy: (), client: client_actions, sync_jobs: sync_jobs_actions };
+    let data = TestData {
+        dummy: (),
+        client: client_actions,
+        sync_jobs: sync_jobs_actions,
+        shards_manager,
+    };
 
     let mut test = builder.build(data);
     test.register_handler(forward_client_messages_from_client_to_client_actions().widen());
     test.register_handler(forward_client_messages_from_sync_jobs_to_client_actions().widen());
+    test.register_handler(forward_client_messages_from_shards_manager().widen());
     test.register_handler(
         forward_sync_jobs_messages_from_client_to_sync_jobs_actions(test.future_spawner()).widen(),
     );
     test.register_handler(drive_futures().widen());
     test.register_handler(drive_delayed_action_runners::<ClientActions>().widen());
-    test.register_handler(ignore_events::<SetChainInfo>().widen());
+    test.register_handler(forward_client_request_to_shards_manager().widen());
     // TODO: handle additional events.
 
     test.delayed_action_runner::<ClientActions>().run_later(
@@ -248,5 +236,5 @@ fn test_client_with_simple_test_loop() {
             client.start(runner);
         },
     );
-    test.run_for(near_async::time::Duration::seconds(1));
+    test.run_for(Duration::seconds(10));
 }

--- a/integration-tests/src/tests/client/process_blocks.rs
+++ b/integration-tests/src/tests/client/process_blocks.rs
@@ -9,6 +9,7 @@ use futures::{future, FutureExt};
 use itertools::Itertools;
 use near_actix_test_utils::run_actix;
 use near_async::messaging::Sender;
+use near_async::time::Duration;
 use near_chain::chain::ApplyStatePartsRequest;
 use near_chain::test_utils::ValidatorSchedule;
 use near_chain::types::{LatestKnown, RuntimeAdapter};
@@ -47,6 +48,7 @@ use near_primitives::sharding::{ShardChunkHeader, ShardChunkHeaderInner, ShardCh
 use near_primitives::state_part::PartId;
 use near_primitives::state_sync::StatePartKey;
 use near_primitives::stateless_validation::ChunkEndorsement;
+use near_primitives::static_clock::StaticClock;
 use near_primitives::test_utils::create_test_signer;
 use near_primitives::test_utils::TestBlockBuilder;
 use near_primitives::transaction::{
@@ -56,7 +58,6 @@ use near_primitives::transaction::{
 use near_primitives::trie_key::TrieKey;
 use near_primitives::types::validator_stake::ValidatorStake;
 use near_primitives::types::{AccountId, BlockHeight, EpochId, NumBlocks, ProtocolVersion};
-use near_primitives::utils::to_timestamp;
 use near_primitives::validator_signer::ValidatorSigner;
 use near_primitives::version::PROTOCOL_VERSION;
 use near_primitives::views::{
@@ -345,7 +346,7 @@ fn receive_network_block() {
                 &signer,
                 last_block.header.next_bp_hash,
                 block_merkle_tree.root(),
-                None,
+                StaticClock::utc(),
             );
             actor_handles.client_actor.do_send(
                 BlockResponse { block, peer_id: PeerInfo::random().id, was_requested: false }
@@ -430,7 +431,7 @@ fn produce_block_with_approvals() {
                 &signer1,
                 last_block.header.next_bp_hash,
                 block_merkle_tree.root(),
-                None,
+                StaticClock::utc(),
             );
             actor_handles.client_actor.do_send(
                 BlockResponse {
@@ -644,7 +645,7 @@ fn invalid_blocks_common(is_requested: bool) {
                 &signer,
                 last_block.header.next_bp_hash,
                 block_merkle_tree.root(),
-                None,
+                StaticClock::utc(),
             );
             // Send block with invalid chunk mask
             let mut block = valid_block.clone();
@@ -1061,7 +1062,7 @@ fn test_time_attack() {
     let genesis = client.chain.get_block_by_height(0).unwrap();
     let mut b1 = TestBlockBuilder::new(&genesis, signer.clone()).build();
     b1.mut_header().get_mut().inner_lite.timestamp =
-        to_timestamp(b1.header().timestamp() + chrono::Duration::seconds(60));
+        (b1.header().timestamp() + Duration::seconds(60)).unix_timestamp() as u64;
     b1.mut_header().resign(signer.as_ref());
 
     let _ = client.process_block_test(b1.into(), Provenance::NONE).unwrap();

--- a/integration-tests/src/tests/client/state_dump.rs
+++ b/integration-tests/src/tests/client/state_dump.rs
@@ -1,5 +1,6 @@
 use assert_matches::assert_matches;
 
+use near_async::time::Duration;
 use near_chain::near_chain_primitives::error::QueryError;
 use near_chain::{ChainGenesis, ChainStoreAccess, Provenance};
 use near_chain_configs::ExternalStorageLocation::Filesystem;
@@ -27,7 +28,6 @@ use nearcore::test_utils::TestEnvNightshadeSetupExt;
 use nearcore::NEAR_BASE;
 use std::ops::ControlFlow;
 use std::sync::Arc;
-use std::time::Duration;
 
 #[test]
 /// Produce several blocks, wait for the state dump thread to notice and

--- a/integration-tests/src/tests/client/sync_state_nodes.rs
+++ b/integration-tests/src/tests/client/sync_state_nodes.rs
@@ -3,6 +3,7 @@ use actix::{Actor, System};
 use futures::{future, FutureExt};
 use near_actix_test_utils::run_actix;
 use near_async::messaging::Sender;
+use near_async::time::Duration;
 use near_chain::chain::ApplyStatePartsRequest;
 use near_chain::Provenance;
 use near_chain_configs::ExternalStorageLocation::Filesystem;
@@ -28,7 +29,6 @@ use nearcore::test_utils::TestEnvNightshadeSetupExt;
 use nearcore::{config::GenesisExt, load_test_config, start_with_config};
 use std::ops::ControlFlow;
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
 
 /// One client is in front, another must sync to it using state (fast) sync.
 #[test]
@@ -160,8 +160,8 @@ fn sync_state_nodes_multishard() {
             near1.network_config.peer_store.boot_nodes =
                 convert_boot_nodes(vec![("test3", *port3), ("test4", *port4)]);
             near1.client_config.min_num_peers = 2;
-            near1.client_config.min_block_production_delay = Duration::from_millis(200);
-            near1.client_config.max_block_production_delay = Duration::from_millis(400);
+            near1.client_config.min_block_production_delay = Duration::milliseconds(200);
+            near1.client_config.max_block_production_delay = Duration::milliseconds(400);
             near1.client_config.epoch_sync_enabled = false;
 
             let mut near3 = load_test_config("test3", port3, genesis.clone());
@@ -218,9 +218,9 @@ fn sync_state_nodes_multishard() {
                                         near2.client_config.skip_sync_wait = false;
                                         near2.client_config.min_num_peers = 3;
                                         near2.client_config.min_block_production_delay =
-                                            Duration::from_millis(200);
+                                            Duration::milliseconds(200);
                                         near2.client_config.max_block_production_delay =
-                                            Duration::from_millis(400);
+                                            Duration::milliseconds(400);
                                         near2.network_config.peer_store.boot_nodes =
                                             convert_boot_nodes(vec![
                                                 ("test1", *port1),
@@ -313,8 +313,8 @@ fn sync_empty_state() {
 
             let mut near1 = load_test_config("test1", port1, genesis.clone());
             near1.client_config.min_num_peers = 0;
-            near1.client_config.min_block_production_delay = Duration::from_millis(200);
-            near1.client_config.max_block_production_delay = Duration::from_millis(400);
+            near1.client_config.min_block_production_delay = Duration::milliseconds(200);
+            near1.client_config.max_block_production_delay = Duration::milliseconds(400);
             near1.client_config.epoch_sync_enabled = false;
 
             let dir1 = tempfile::Builder::new().prefix("sync_nodes_1").tempdir().unwrap();
@@ -348,9 +348,9 @@ fn sync_empty_state() {
                                             convert_boot_nodes(vec![("test1", *port1)]);
                                         near2.client_config.min_num_peers = 1;
                                         near2.client_config.min_block_production_delay =
-                                            Duration::from_millis(200);
+                                            Duration::milliseconds(200);
                                         near2.client_config.max_block_production_delay =
-                                            Duration::from_millis(400);
+                                            Duration::milliseconds(400);
                                         near2.client_config.block_header_fetch_horizon =
                                             block_header_fetch_horizon;
                                         near2.client_config.block_fetch_horizon =
@@ -443,15 +443,15 @@ fn sync_state_dump() {
             let mut near1 = load_test_config("test1", port1, genesis.clone());
             near1.client_config.min_num_peers = 0;
             // An epoch passes in about 9 seconds.
-            near1.client_config.min_block_production_delay = Duration::from_millis(300);
-            near1.client_config.max_block_production_delay = Duration::from_millis(600);
+            near1.client_config.min_block_production_delay = Duration::milliseconds(300);
+            near1.client_config.max_block_production_delay = Duration::milliseconds(600);
             near1.client_config.epoch_sync_enabled = false;
             near1.client_config.tracked_shards = vec![0]; // Track all shards.
             let dump_dir = tempfile::Builder::new().prefix("state_dump_1").tempdir().unwrap();
             near1.client_config.state_sync.dump = Some(DumpConfig {
                 location: Filesystem { root_dir: dump_dir.path().to_path_buf() },
                 restart_dump_for_shards: None,
-                iteration_delay: Some(Duration::from_millis(500)),
+                iteration_delay: Some(Duration::milliseconds(500)),
                 credentials_file: None,
             });
             near1.config.store.state_snapshot_enabled = true;
@@ -486,16 +486,16 @@ fn sync_state_dump() {
                                     convert_boot_nodes(vec![("test1", *port1)]);
                                 near2.client_config.min_num_peers = 1;
                                 near2.client_config.min_block_production_delay =
-                                    Duration::from_millis(300);
+                                    Duration::milliseconds(300);
                                 near2.client_config.max_block_production_delay =
-                                    Duration::from_millis(600);
+                                    Duration::milliseconds(600);
                                 near2.client_config.block_header_fetch_horizon =
                                     block_header_fetch_horizon;
                                 near2.client_config.block_fetch_horizon = block_fetch_horizon;
                                 near2.client_config.tracked_shards = vec![0]; // Track all shards.
                                 near2.client_config.epoch_sync_enabled = false;
                                 near2.client_config.state_sync_enabled = true;
-                                near2.client_config.state_sync_timeout = Duration::from_secs(2);
+                                near2.client_config.state_sync_timeout = Duration::seconds(2);
                                 near2.client_config.state_sync.sync =
                                     SyncConfig::ExternalStorage(ExternalStorageConfig {
                                         location: Filesystem {

--- a/integration-tests/src/tests/nearcore/sync_nodes.rs
+++ b/integration-tests/src/tests/nearcore/sync_nodes.rs
@@ -4,6 +4,7 @@ use crate::test_helpers::heavy_test;
 use actix::{Actor, System};
 use futures::{future, FutureExt};
 use near_actix_test_utils::run_actix;
+use near_async::time::Duration;
 use near_chain_configs::Genesis;
 use near_client::{GetBlock, ProcessTxRequest};
 use near_crypto::{InMemorySigner, KeyType};
@@ -17,7 +18,6 @@ use nearcore::config::{GenesisExt, TESTING_INIT_STAKE};
 use nearcore::{load_test_config, start_with_config};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, RwLock};
-use std::time::Duration;
 
 /// One client is in front, another must sync to it before they can produce blocks.
 #[test]
@@ -141,11 +141,11 @@ fn sync_state_stake_change() {
         let mut near1 = load_test_config("test1", port1, genesis.clone());
         near1.network_config.peer_store.boot_nodes = convert_boot_nodes(vec![("test2", *port2)]);
         near1.client_config.min_num_peers = 0;
-        near1.client_config.min_block_production_delay = Duration::from_millis(200);
+        near1.client_config.min_block_production_delay = Duration::milliseconds(200);
         near1.client_config.epoch_sync_enabled = false;
         let mut near2 = load_test_config("test2", port2, genesis.clone());
         near2.network_config.peer_store.boot_nodes = convert_boot_nodes(vec![("test1", *port1)]);
-        near2.client_config.min_block_production_delay = Duration::from_millis(200);
+        near2.client_config.min_block_production_delay = Duration::milliseconds(200);
         near2.client_config.min_num_peers = 1;
         near2.client_config.skip_sync_wait = false;
         near2.client_config.epoch_sync_enabled = false;

--- a/nearcore/src/cold_storage.rs
+++ b/nearcore/src/cold_storage.rs
@@ -304,8 +304,8 @@ fn cold_store_initial_migration_loop(
             // Here we pick the second option.
             Err(err) => {
                 let dur = split_storage_config.cold_store_initial_migration_loop_sleep_duration;
-                tracing::error!(target: "cold_store", "initial migration failed with error {}, sleeping {}s and trying again", err, dur.as_secs());
-                std::thread::sleep(dur);
+                tracing::error!(target: "cold_store", "initial migration failed with error {}, sleeping {}s and trying again", err, dur.whole_seconds());
+                std::thread::sleep(dur.unsigned_abs());
             }
             // Any Ok status from `cold_store_initial_migration` function means that we can proceed to regular run.
             Ok(status) => {
@@ -360,17 +360,17 @@ fn cold_store_loop(
         match result {
             Err(err) => {
                 tracing::error!(target : "cold_store", error = format!("{err:#?}"), "cold_store_copy failed");
-                std::thread::sleep(sleep_duration);
+                std::thread::sleep(sleep_duration.unsigned_abs());
             }
             // If no block was copied the cold head is up to date with final head and
             // this loop should sleep while waiting for a new block to get finalized.
             Ok(ColdStoreCopyResult::NoBlockCopied) => {
-                std::thread::sleep(sleep_duration);
+                std::thread::sleep(sleep_duration.unsigned_abs());
             }
             // The final head block was copied. There are no more blocks to be copied now
             // this loop should sleep while waiting for a new block to get finalized.
             Ok(ColdStoreCopyResult::LatestBlockCopied) => {
-                std::thread::sleep(sleep_duration);
+                std::thread::sleep(sleep_duration.unsigned_abs());
             }
             // A block older than the final head was copied. We should continue copying
             // until cold head reaches final head.

--- a/nearcore/src/config.rs
+++ b/nearcore/src/config.rs
@@ -1,6 +1,7 @@
 use crate::download_file::{run_download_file, FileDownloadError};
 use crate::dyn_config::LOG_CONFIG_FILENAME;
 use anyhow::{anyhow, bail, Context};
+use near_async::time::Duration;
 use near_chain_configs::{
     default_enable_multiline_logging, default_epoch_sync_enabled,
     default_header_sync_expected_height_per_second, default_header_sync_initial_timeout,
@@ -33,7 +34,7 @@ use near_primitives::types::{
     AccountId, AccountInfo, Balance, BlockHeight, BlockHeightDelta, Gas, NumBlocks, NumSeats,
     NumShards, ShardId,
 };
-use near_primitives::utils::{generate_random_string, get_num_seats_per_shard};
+use near_primitives::utils::{from_timestamp, generate_random_string, get_num_seats_per_shard};
 use near_primitives::validator_signer::{InMemoryValidatorSigner, ValidatorSigner};
 use near_primitives::version::PROTOCOL_VERSION;
 #[cfg(feature = "rosetta_rpc")]
@@ -46,7 +47,6 @@ use std::io::{Read, Write};
 use std::path::Path;
 use std::str::FromStr;
 use std::sync::Arc;
-use std::time::Duration;
 #[cfg(test)]
 use tempfile::tempdir;
 use tracing::{info, warn};
@@ -64,26 +64,26 @@ pub const NEAR_BASE: Balance = 1_000_000_000_000_000_000_000_000;
 pub const MILLI_NEAR: Balance = NEAR_BASE / 1000;
 
 /// Block production tracking delay.
-pub const BLOCK_PRODUCTION_TRACKING_DELAY: u64 = 100;
+pub const BLOCK_PRODUCTION_TRACKING_DELAY: i64 = 100;
 
 /// Expected block production time in ms.
-pub const MIN_BLOCK_PRODUCTION_DELAY: u64 = 600;
+pub const MIN_BLOCK_PRODUCTION_DELAY: i64 = 600;
 
 /// Mainnet and testnet validators are configured with a different value due to
 /// performance values.
-pub const MAINNET_MIN_BLOCK_PRODUCTION_DELAY: u64 = 1_300;
-pub const TESTNET_MIN_BLOCK_PRODUCTION_DELAY: u64 = 1_000;
+pub const MAINNET_MIN_BLOCK_PRODUCTION_DELAY: i64 = 1_300;
+pub const TESTNET_MIN_BLOCK_PRODUCTION_DELAY: i64 = 1_000;
 
 /// Maximum time to delay block production without approvals is ms.
-pub const MAX_BLOCK_PRODUCTION_DELAY: u64 = 2_000;
+pub const MAX_BLOCK_PRODUCTION_DELAY: i64 = 2_000;
 
 /// Mainnet and testnet validators are configured with a different value due to
 /// performance values.
-pub const MAINNET_MAX_BLOCK_PRODUCTION_DELAY: u64 = 3_000;
-pub const TESTNET_MAX_BLOCK_PRODUCTION_DELAY: u64 = 2_500;
+pub const MAINNET_MAX_BLOCK_PRODUCTION_DELAY: i64 = 3_000;
+pub const TESTNET_MAX_BLOCK_PRODUCTION_DELAY: i64 = 2_500;
 
 /// Maximum time until skipping the previous block is ms.
-pub const MAX_BLOCK_WAIT_DELAY: u64 = 6_000;
+pub const MAX_BLOCK_WAIT_DELAY: i64 = 6_000;
 
 /// Horizon at which instead of fetching block, fetch full state.
 const BLOCK_FETCH_HORIZON: BlockHeightDelta = 50;
@@ -92,13 +92,14 @@ const BLOCK_FETCH_HORIZON: BlockHeightDelta = 50;
 const BLOCK_HEADER_FETCH_HORIZON: BlockHeightDelta = 50;
 
 /// Time between check to perform catchup.
-const CATCHUP_STEP_PERIOD: u64 = 100;
+const CATCHUP_STEP_PERIOD: i64 = 100;
 
 /// Time between checking to re-request chunks.
-const CHUNK_REQUEST_RETRY_PERIOD: u64 = 400;
+const CHUNK_REQUEST_RETRY_PERIOD: i64 = 400;
 
 /// Expected epoch length.
-pub const EXPECTED_EPOCH_LENGTH: BlockHeightDelta = (5 * 60 * 1000) / MIN_BLOCK_PRODUCTION_DELAY;
+pub const EXPECTED_EPOCH_LENGTH: BlockHeightDelta =
+    ((5 * 60 * 1000) / MIN_BLOCK_PRODUCTION_DELAY) as u64;
 
 /// Criterion for kicking out block producers.
 pub const BLOCK_PRODUCER_KICKOUT_THRESHOLD: u8 = 90;
@@ -107,8 +108,8 @@ pub const BLOCK_PRODUCER_KICKOUT_THRESHOLD: u8 = 90;
 pub const CHUNK_PRODUCER_KICKOUT_THRESHOLD: u8 = 90;
 
 /// Fast mode constants for testing/developing.
-pub const FAST_MIN_BLOCK_PRODUCTION_DELAY: u64 = 120;
-pub const FAST_MAX_BLOCK_PRODUCTION_DELAY: u64 = 500;
+pub const FAST_MIN_BLOCK_PRODUCTION_DELAY: i64 = 120;
+pub const FAST_MAX_BLOCK_PRODUCTION_DELAY: i64 = 500;
 pub const FAST_EPOCH_LENGTH: BlockHeightDelta = 60;
 
 /// Expected number of blocks per year
@@ -157,7 +158,7 @@ pub const MAX_INFLATION_RATE: Rational32 = Rational32::new_raw(1, 20);
 pub const PROTOCOL_UPGRADE_STAKE_THRESHOLD: Rational32 = Rational32::new_raw(4, 5);
 
 fn default_doomslug_step_period() -> Duration {
-    Duration::from_millis(100)
+    Duration::milliseconds(100)
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
@@ -214,15 +215,17 @@ impl Default for Consensus {
     fn default() -> Self {
         Consensus {
             min_num_peers: 3,
-            block_production_tracking_delay: Duration::from_millis(BLOCK_PRODUCTION_TRACKING_DELAY),
-            min_block_production_delay: Duration::from_millis(MIN_BLOCK_PRODUCTION_DELAY),
-            max_block_production_delay: Duration::from_millis(MAX_BLOCK_PRODUCTION_DELAY),
-            max_block_wait_delay: Duration::from_millis(MAX_BLOCK_WAIT_DELAY),
+            block_production_tracking_delay: Duration::milliseconds(
+                BLOCK_PRODUCTION_TRACKING_DELAY,
+            ),
+            min_block_production_delay: Duration::milliseconds(MIN_BLOCK_PRODUCTION_DELAY),
+            max_block_production_delay: Duration::milliseconds(MAX_BLOCK_PRODUCTION_DELAY),
+            max_block_wait_delay: Duration::milliseconds(MAX_BLOCK_WAIT_DELAY),
             produce_empty_blocks: true,
             block_fetch_horizon: BLOCK_FETCH_HORIZON,
             block_header_fetch_horizon: BLOCK_HEADER_FETCH_HORIZON,
-            catchup_step_period: Duration::from_millis(CATCHUP_STEP_PERIOD),
-            chunk_request_retry_period: Duration::from_millis(CHUNK_REQUEST_RETRY_PERIOD),
+            catchup_step_period: Duration::milliseconds(CATCHUP_STEP_PERIOD),
+            chunk_request_retry_period: Duration::milliseconds(CHUNK_REQUEST_RETRY_PERIOD),
             header_sync_initial_timeout: default_header_sync_initial_timeout(),
             header_sync_progress_timeout: default_header_sync_progress_timeout(),
             header_sync_stall_ban_timeout: default_header_sync_stall_ban_timeout(),
@@ -385,7 +388,7 @@ fn default_cold_store_initial_migration_batch_size() -> usize {
 }
 
 fn default_cold_store_initial_migration_loop_sleep_duration() -> Duration {
-    Duration::from_secs(30)
+    Duration::seconds(30)
 }
 
 fn default_num_cold_store_read_threads() -> usize {
@@ -393,7 +396,7 @@ fn default_num_cold_store_read_threads() -> usize {
 }
 
 fn default_cold_store_loop_sleep_duration() -> Duration {
-    Duration::from_secs(1)
+    Duration::seconds(1)
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Clone, Debug)]
@@ -533,7 +536,7 @@ impl Genesis {
         add_protocol_account(&mut records);
         let config = GenesisConfig {
             protocol_version: PROTOCOL_VERSION,
-            genesis_time: StaticClock::utc(),
+            genesis_time: from_timestamp(StaticClock::utc().unix_timestamp() as u64),
             chain_id: random_chain_id(),
             num_block_producer_seats: num_validator_seats,
             num_block_producer_seats_per_shard: num_validator_seats_per_shard.clone(),
@@ -909,22 +912,22 @@ fn set_block_production_delay(chain_id: &str, fast: bool, config: &mut Config) {
     match chain_id {
         near_primitives::chains::MAINNET => {
             config.consensus.min_block_production_delay =
-                Duration::from_millis(MAINNET_MIN_BLOCK_PRODUCTION_DELAY);
+                Duration::milliseconds(MAINNET_MIN_BLOCK_PRODUCTION_DELAY);
             config.consensus.max_block_production_delay =
-                Duration::from_millis(MAINNET_MAX_BLOCK_PRODUCTION_DELAY);
+                Duration::milliseconds(MAINNET_MAX_BLOCK_PRODUCTION_DELAY);
         }
         near_primitives::chains::TESTNET => {
             config.consensus.min_block_production_delay =
-                Duration::from_millis(TESTNET_MIN_BLOCK_PRODUCTION_DELAY);
+                Duration::milliseconds(TESTNET_MIN_BLOCK_PRODUCTION_DELAY);
             config.consensus.max_block_production_delay =
-                Duration::from_millis(TESTNET_MAX_BLOCK_PRODUCTION_DELAY);
+                Duration::milliseconds(TESTNET_MAX_BLOCK_PRODUCTION_DELAY);
         }
         _ => {
             if fast {
                 config.consensus.min_block_production_delay =
-                    Duration::from_millis(FAST_MIN_BLOCK_PRODUCTION_DELAY);
+                    Duration::milliseconds(FAST_MIN_BLOCK_PRODUCTION_DELAY);
                 config.consensus.max_block_production_delay =
-                    Duration::from_millis(FAST_MAX_BLOCK_PRODUCTION_DELAY);
+                    Duration::milliseconds(FAST_MAX_BLOCK_PRODUCTION_DELAY);
             }
         }
     }
@@ -1116,7 +1119,7 @@ pub fn init_configs(
 
             let genesis_config = GenesisConfig {
                 protocol_version: PROTOCOL_VERSION,
-                genesis_time: StaticClock::utc(),
+                genesis_time: from_timestamp(StaticClock::utc().unix_timestamp() as u64),
                 chain_id,
                 genesis_height: 0,
                 num_block_producer_seats: NUM_BLOCK_PRODUCER_SEATS,
@@ -1189,8 +1192,8 @@ pub fn create_testnet_configs_from_seeds(
     for i in 0..seeds.len() {
         let mut config = Config::default();
         config.rpc.get_or_insert(Default::default()).enable_debug_rpc = true;
-        config.consensus.min_block_production_delay = Duration::from_millis(600);
-        config.consensus.max_block_production_delay = Duration::from_millis(2000);
+        config.consensus.min_block_production_delay = Duration::milliseconds(600);
+        config.consensus.max_block_production_delay = Duration::milliseconds(2000);
         if local_ports {
             config.network.addr = if i == 0 {
                 first_node_addr.to_string()
@@ -1468,9 +1471,9 @@ pub fn load_test_config(seed: &str, addr: tcp::ListenerAddr, genesis: Genesis) -
     config.network.addr = addr.to_string();
     config.set_rpc_addr(tcp::ListenerAddr::reserve_for_test());
     config.consensus.min_block_production_delay =
-        Duration::from_millis(FAST_MIN_BLOCK_PRODUCTION_DELAY);
+        Duration::milliseconds(FAST_MIN_BLOCK_PRODUCTION_DELAY);
     config.consensus.max_block_production_delay =
-        Duration::from_millis(FAST_MAX_BLOCK_PRODUCTION_DELAY);
+        Duration::milliseconds(FAST_MAX_BLOCK_PRODUCTION_DELAY);
     let (signer, validator_signer) = if seed.is_empty() {
         let signer =
             Arc::new(InMemorySigner::from_random("node".parse().unwrap(), KeyType::ED25519));

--- a/nearcore/src/metrics.rs
+++ b/nearcore/src/metrics.rs
@@ -1,6 +1,7 @@
 use std::rc::Rc;
 
 use actix_rt::ArbiterHandle;
+use near_async::time::Duration;
 use near_chain::{Block, ChainStore, ChainStoreAccess};
 use near_epoch_manager::EpochManager;
 use near_o11y::metrics::{
@@ -253,13 +254,13 @@ fn get_postponed_receipt_count_for_trie(trie: Trie) -> Result<i64, anyhow::Error
 pub fn spawn_trie_metrics_loop(
     near_config: NearConfig,
     store: Store,
-    period: std::time::Duration,
+    period: Duration,
 ) -> anyhow::Result<ArbiterHandle> {
     tracing::debug!(target:"metrics", "Spawning the trie metrics loop.");
     let arbiter = actix_rt::Arbiter::new();
 
     let start = tokio::time::Instant::now();
-    let mut interval = actix_rt::time::interval_at(start, period);
+    let mut interval = actix_rt::time::interval_at(start, period.unsigned_abs());
     interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
 
     arbiter.spawn(async move {

--- a/nearcore/src/runtime/mod.rs
+++ b/nearcore/src/runtime/mod.rs
@@ -4,6 +4,7 @@ use crate::NearConfig;
 
 use borsh::BorshDeserialize;
 use errors::FromStateViewerErrors;
+use near_async::time::{Duration, Instant};
 use near_chain::types::{
     ApplyChunkBlockContext, ApplyChunkResult, ApplyChunkShardContext, ApplyResultForResharding,
     PrepareTransactionsBlockContext, PrepareTransactionsChunkContext, PrepareTransactionsLimit,
@@ -57,8 +58,6 @@ use node_runtime::{
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
-use std::time::Duration;
-use std::time::Instant;
 use tracing::{debug, error, info};
 
 pub mod errors;
@@ -444,7 +443,7 @@ impl NightshadeRuntime {
             apply_result.outcomes.iter().map(|tx_result| tx_result.outcome.gas_burnt).sum();
         metrics::APPLY_CHUNK_DELAY
             .with_label_values(&[&format_total_gas_burnt(total_gas_burnt)])
-            .observe(elapsed.as_secs_f64());
+            .observe(elapsed.as_seconds_f64());
         let shard_label = shard_id.to_string();
         metrics::DELAYED_RECEIPTS_COUNT
             .with_label_values(&[&shard_label])
@@ -1093,7 +1092,7 @@ impl RuntimeAdapter for NightshadeRuntime {
         let is_ok = if res.is_ok() { "ok" } else { "error" };
         metrics::STATE_SYNC_OBTAIN_PART_DELAY
             .with_label_values(&[&shard_id.to_string(), is_ok])
-            .observe(elapsed.as_secs_f64());
+            .observe(elapsed.as_seconds_f64());
         res
     }
 

--- a/nearcore/src/state_sync.rs
+++ b/nearcore/src/state_sync.rs
@@ -1,6 +1,7 @@
 use crate::metrics;
 
 use borsh::BorshSerialize;
+use near_async::time::{Duration, Instant};
 use near_chain::types::RuntimeAdapter;
 use near_chain::{Chain, ChainGenesis, ChainStoreAccess, DoomslugThresholdMode, Error};
 use near_chain_configs::{ClientConfig, ExternalStorageLocation};
@@ -23,7 +24,6 @@ use rand::{thread_rng, Rng};
 use std::collections::HashSet;
 use std::sync::atomic::AtomicBool;
 use std::sync::Arc;
-use std::time::{Duration, Instant};
 
 /// Starts one a thread per tracked shard.
 /// Each started thread will be dumping state parts of a single epoch to external storage.
@@ -46,7 +46,7 @@ pub fn spawn_state_sync_dump(
 
     let external = match dump_config.location {
         ExternalStorageLocation::S3 { bucket, region } => ExternalConnection::S3{
-            bucket: Arc::new(create_bucket_readwrite(&bucket, &region, Duration::from_secs(30), dump_config.credentials_file).expect(
+            bucket: Arc::new(create_bucket_readwrite(&bucket, &region, std::time::Duration::from_secs(30), dump_config.credentials_file).expect(
                 "Failed to authenticate connection to S3. Please either provide AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in the environment, or create a credentials file and link it in config.json as 's3_credentials_file'."))
         },
         ExternalStorageLocation::Filesystem { root_dir } => ExternalConnection::Filesystem { root_dir },
@@ -110,7 +110,7 @@ pub fn spawn_state_sync_dump(
                 chain_id.clone(),
                 dump_config.restart_dump_for_shards.clone().unwrap_or_default(),
                 external.clone(),
-                dump_config.iteration_delay.unwrap_or(Duration::from_secs(10)),
+                dump_config.iteration_delay.unwrap_or(Duration::seconds(10)),
                 account_id.clone(),
                 keep_running.clone(),
             )));
@@ -416,7 +416,7 @@ async fn state_sync_dump(
                                 // Stop if the node is stopped.
                                 // Note that without this check the state dumping thread is unstoppable, i.e. non-interruptable.
                                 while keep_running.load(std::sync::atomic::Ordering::Relaxed)
-                                    && timer.elapsed().as_secs()
+                                    && timer.elapsed().whole_seconds()
                                         <= STATE_DUMP_ITERATION_TIME_LIMIT_SECS
                                     && !parts_to_dump.is_empty()
                                     && failures_cnt < FAILURES_ALLOWED_PER_ITERATION
@@ -528,7 +528,7 @@ async fn state_sync_dump(
 
         if !has_progress {
             // Avoid a busy-loop when there is nothing to do.
-            actix_rt::time::sleep(tokio::time::Duration::from(iteration_delay)).await;
+            actix_rt::time::sleep(iteration_delay.unsigned_abs()).await;
         }
     }
     tracing::debug!(target: "state_sync_dump", shard_id, "Stopped state dump thread");

--- a/tools/amend-genesis/src/lib.rs
+++ b/tools/amend-genesis/src/lib.rs
@@ -424,7 +424,7 @@ mod test {
     use near_primitives::state_record::StateRecord;
     use near_primitives::static_clock::StaticClock;
     use near_primitives::types::{AccountId, AccountInfo};
-    use near_primitives::utils;
+    use near_primitives::utils::{self, from_timestamp};
     use near_primitives::version::PROTOCOL_VERSION;
     use near_primitives_core::account::{AccessKey, Account};
     use near_primitives_core::types::{Balance, StorageUsage};
@@ -614,7 +614,7 @@ mod test {
 
             let genesis_config = GenesisConfig {
                 protocol_version: PROTOCOL_VERSION,
-                genesis_time: StaticClock::utc(),
+                genesis_time: from_timestamp(StaticClock::utc().unix_timestamp() as u64),
                 chain_id: "rusttestnet".to_string(),
                 genesis_height: 0,
                 num_block_producer_seats: nearcore::config::NUM_BLOCK_PRODUCER_SEATS,

--- a/tools/mirror/Cargo.toml
+++ b/tools/mirror/Cargo.toml
@@ -35,6 +35,7 @@ tokio.workspace = true
 tracing.workspace = true
 
 nearcore.workspace = true
+near-async.workspace = true
 near-chain-configs.workspace = true
 near-chain.workspace = true
 near-chain-primitives.workspace = true

--- a/tools/mirror/src/chain_tracker.rs
+++ b/tools/mirror/src/chain_tracker.rs
@@ -456,7 +456,8 @@ impl TxTracker {
         // in the target chain. In the second or so between now and then, we might process another block
         // that will set the nonces.
         if let Some(s) = &self.send_time {
-            tokio::time::sleep_until(s.as_ref().deadline() - Duration::from_millis(20)).await;
+            tokio::time::sleep_until(s.as_ref().deadline() - std::time::Duration::from_millis(20))
+                .await;
         }
         let mut needed_access_keys = HashSet::new();
         for c in self.queued_blocks[0].chunks.iter_mut() {

--- a/tools/mirror/src/lib.rs
+++ b/tools/mirror/src/lib.rs
@@ -894,7 +894,8 @@ impl<T: ChainAccess> TxMirror<T> {
             target_genesis_height: target_config.genesis.config.genesis_height,
             target_min_block_production_delay: target_config
                 .client_config
-                .min_block_production_delay,
+                .min_block_production_delay
+                .unsigned_abs(),
             tracked_shards: target_config.config.tracked_shards,
             secret,
             default_extra_key,
@@ -1699,7 +1700,7 @@ impl<T: ChainAccess> TxMirror<T> {
                 }
                 // If we don't have any upcoming sets of transactions to send already built, we probably fell behind in the source
                 // chain and can't fetch the transactions. Check if we have them now here.
-                _ = tokio::time::sleep(Duration::from_millis(200)), if tracker.num_blocks_queued() == 0 => {
+                _ = tokio::time::sleep(std::time::Duration::from_millis(200)), if tracker.num_blocks_queued() == 0 => {
                     self.queue_txs(&mut tracker, target_head, true).await?;
                 }
             };

--- a/tools/mock-node/src/setup.rs
+++ b/tools/mock-node/src/setup.rs
@@ -73,7 +73,7 @@ fn setup_mock_peer(
             mock_listen_addr,
             chain_id,
             archival,
-            block_production_delay,
+            block_production_delay.unsigned_abs(),
             num_shards,
             network_start_height,
             network_config,


### PR DESCRIPTION
This allows us to use Clock's everywhere rather than the StaticClock.

The simple_test_loop_example.rs now is able to produce blocks with a single client on a single-validator blockchain. It entirely happens in a single thread. The visualizer shows events related to block production and processing:

<img width="1728" alt="image" src="https://github.com/robin-near/nearcore/assets/111538878/f3989f95-858b-49fe-b504-11a483e33dc7">
